### PR TITLE
🎨 Palette: Add accessibility properties to icon-only buttons in PremiumHeader and SpeedDialMenu

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-28 - Icon-Only Button Accessibility in Search
 **Learning:** Icon-only action buttons (like scan barcode, voice search, and submit inputs) are completely inaccessible to screen reader users if missing proper accessibility props, as they provide no context about their function.
 **Action:** Always add `accessibilityRole="button"` and an explicit `accessibilityLabel` (e.g., "Scan barcode with camera") to icon-only `TouchableOpacity` elements, along with `accessibilityState` for dynamic states like disabled or checked.
+
+## 2024-05-15 - Missing Accessibility Labels on Icon-Only UI Components
+**Learning:** Custom interactive UI components like `SpeedDialMenu` and `PremiumHeader` that rely exclusively on visual icons (like Ionicons) without accompanying text frequently omit `accessibilityLabel` and `accessibilityRole`. This is a common accessibility trap when developers focus purely on "modern" glassmorphic or animated aesthetics. Screen readers just hear "button" or nothing at all, making these key navigation and action items completely invisible to visually impaired users.
+**Action:** Always ensure that icon-only `TouchableOpacity` or `Animated.View` interactive components include an explicit `accessibilityLabel` that describes the action (e.g., "Menu", "Log out", or the specific action label) and an `accessibilityRole="button"`. For toggle states, include `accessibilityState={{ expanded: boolean }}`.

--- a/frontend/src/components/ui/PremiumHeader.tsx
+++ b/frontend/src/components/ui/PremiumHeader.tsx
@@ -48,6 +48,7 @@ interface PremiumHeaderProps {
     icon: keyof typeof Ionicons.glyphMap;
     onPress: () => void;
     color?: string;
+    accessibilityLabel?: string;
   };
   style?: ViewStyle;
 }
@@ -119,6 +120,8 @@ export const PremiumHeader: React.FC<PremiumHeaderProps> = ({
           ]}
           onPress={rightAction.onPress}
           activeOpacity={0.7}
+          accessibilityLabel={rightAction.accessibilityLabel || "Header action"}
+          accessibilityRole="button"
         >
           <Ionicons
             name={rightAction.icon}
@@ -135,6 +138,8 @@ export const PremiumHeader: React.FC<PremiumHeaderProps> = ({
           style={[styles.actionButton, styles.logoutButton]}
           onPress={onLogout}
           activeOpacity={0.7}
+          accessibilityLabel="Log out"
+          accessibilityRole="button"
         >
           <Ionicons
             name="log-out-outline"
@@ -151,6 +156,8 @@ export const PremiumHeader: React.FC<PremiumHeaderProps> = ({
           style={styles.actionButton}
           onPress={onMenuPress}
           activeOpacity={0.7}
+          accessibilityLabel="Menu"
+          accessibilityRole="button"
         >
           <Ionicons
             name="menu-outline"

--- a/frontend/src/components/ui/SpeedDialMenu.tsx
+++ b/frontend/src/components/ui/SpeedDialMenu.tsx
@@ -87,6 +87,8 @@ const SpeedDialActionItem: React.FC<SpeedDialActionItemProps> = ({
       style={[styles.actionButton, actionStyle]}
       onPress={() => onPress(action)}
       activeOpacity={0.9}
+      accessibilityLabel={action.label}
+      accessibilityRole="button"
     >
       <View style={styles.actionContent}>
         {/* Label */}
@@ -222,6 +224,8 @@ export const SpeedDialMenu: React.FC<SpeedDialMenuProps> = ({
           style={StyleSheet.absoluteFill}
           onPress={toggleMenu}
           activeOpacity={1}
+          accessibilityLabel="Close speed dial menu"
+          accessibilityRole="button"
         />
       </AnimatedBlurView>
 
@@ -243,6 +247,9 @@ export const SpeedDialMenu: React.FC<SpeedDialMenuProps> = ({
           style={styles.mainButton}
           onPress={toggleMenu}
           activeOpacity={0.9}
+          accessibilityLabel={isOpen ? "Close speed dial menu" : "Open speed dial menu"}
+          accessibilityRole="button"
+          accessibilityState={{ expanded: isOpen }}
         >
           <LinearGradient
             colors={mainColor}


### PR DESCRIPTION
## **User description**
💡 What: Added missing `accessibilityLabel` and `accessibilityRole` properties to icon-only buttons within `PremiumHeader.tsx` and `SpeedDialMenu.tsx`. Also added a journal entry to `.Jules/palette.md` detailing these findings.
🎯 Why: Without these explicit accessibility labels, screen reader users navigate over these interactive elements and either hear nothing or just generic "button" readouts. This makes key functionality like "Menu", "Log out", and "Close speed dial menu" entirely undiscoverable.
♿ Accessibility:
- Added explicit `accessibilityLabel` properties describing actions.
- Enforced `accessibilityRole="button"`.
- Used `accessibilityState={{ expanded: isOpen }}` for the main toggle button in the SpeedDialMenu.

---
*PR created automatically by Jules for task [13492873023915205583](https://jules.google.com/task/13492873023915205583) started by @mknoufi*


___

## **CodeAnt-AI Description**
Add accessibility labels and roles to icon-only header and speed-dial buttons

### What Changed
- Icon-only action buttons in PremiumHeader now expose readable labels and the role: "Menu", "Log out", and a configurable label for the right-side action so screen readers announce their purpose.
- SpeedDialMenu action buttons and backdrop receive accessible labels and roles; the main speed-dial toggle now exposes its open/closed state so screen readers hear "Open speed dial menu" or "Close speed dial menu" and "expanded" status.
- Added a journal note documenting the accessibility requirement for icon-only touchables.

### Impact
`✅ Clearer screen reader labels for header actions`
`✅ Discoverable speed-dial actions and close control`
`✅ Screen readers receive toggle state for the speed-dial button`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
