### PR TITLE
🎨 Palette: Make Accordion accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-28 - Icon-Only Button Accessibility in Search
 **Learning:** Icon-only action buttons (like scan barcode, voice search, and submit inputs) are completely inaccessible to screen reader users if missing proper accessibility props, as they provide no context about their function.
 **Action:** Always add `accessibilityRole="button"` and an explicit `accessibilityLabel` (e.g., "Scan barcode with camera") to icon-only `TouchableOpacity` elements, along with `accessibilityState` for dynamic states like disabled or checked.
+
+## 2024-05-24 - Accordion Accessibility Pattern
+**Learning:** Custom interactive components like `Accordion` sections often lack native accessibility attributes. When users navigate to these items with screen readers, they hear just the text (e.g., "Settings") without knowing it's an expandable button or its current state.
+**Action:** Always ensure accordion headers have `accessibilityRole="button"`, `accessibilityState={{ expanded: isExpanded }}`, and clear `accessibilityHint`s describing the outcome of activating them (e.g., "Double tap to expand/collapse").

--- a/frontend/src/components/ui/Accordion.tsx
+++ b/frontend/src/components/ui/Accordion.tsx
@@ -129,6 +129,10 @@ const AccordionItemComponent: React.FC<AccordionItemComponentProps> = ({
         style={styles.header}
         onPress={onToggle}
         activeOpacity={0.7}
+        accessibilityRole="button"
+        accessibilityState={{ expanded: isExpanded }}
+        accessibilityLabel={item.title}
+        accessibilityHint={isExpanded ? "Double tap to collapse" : "Double tap to expand"}
       >
         {item.icon && (
           <Ionicons


### PR DESCRIPTION
## **User description**
💡 What: Added necessary accessibility attributes (`accessibilityRole`, `accessibilityState`, `accessibilityLabel`, `accessibilityHint`) to the `Accordion` component's header.
🎯 Why: Screen reader users were previously unable to determine that the accordion headers were expandable buttons or discern their current expanded/collapsed state, making the component difficult to use.
♿ Accessibility: The changes introduce proper ARIA-equivalent roles, states, and action hints to the component, ensuring it is announced accurately by assistive technologies. Added a learning regarding this pattern to the palette journal.

---
*PR created automatically by Jules for task [11135855640270925055](https://jules.google.com/task/11135855640270925055) started by @mknoufi*


___

## **CodeAnt-AI Description**
**Make Accordion headers accessible to screen readers**

### What Changed
- Accordion header buttons now expose an accessibility role, explicit label, current expanded/collapsed state, and a hint describing the effect of tapping (expand or collapse)
- Palette journal updated with a clear guideline for adding accessibility role, state, and hints to accordion headers

### Impact
`✅ Clearer screen reader announcements for accordion headers`
`✅ Easier discovery of expandable sections for assistive technology users`
`✅ Consistent accessibility guidance recorded in the palette journal`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
