### PR TITLE
🎨 Palette: Make Toast notifications accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-28 - Icon-Only Button Accessibility in Search
 **Learning:** Icon-only action buttons (like scan barcode, voice search, and submit inputs) are completely inaccessible to screen reader users if missing proper accessibility props, as they provide no context about their function.
 **Action:** Always add `accessibilityRole="button"` and an explicit `accessibilityLabel` (e.g., "Scan barcode with camera") to icon-only `TouchableOpacity` elements, along with `accessibilityState` for dynamic states like disabled or checked.
+
+## 2024-05-23 - Accessible Transient Overlay Notifications
+**Learning:** Transient overlay components (like Toast notifications) are not naturally announced by screen readers when they appear, making critical context (like "Save successful" or "Sync failed") invisible to non-sighted users. Their internal action buttons (like "Dismiss" or "Undo") also lack context if they are icon-only or dynamic text without explicit roles.
+**Action:** Always add `accessibilityRole="alert"` and `accessibilityLiveRegion` (set to "assertive" for errors, "polite" for info) to the transient feedback elements. Never wrap these elements in an `accessible={true}` view if they contain interactive children (like action buttons), as React Native groups all child elements into a single non-interactive selectable element for screen readers. Always add explicit `accessibilityRole="button"`, `accessibilityLabel`, and `accessibilityHint` to their internal action buttons.

--- a/frontend/src/components/ui/Toast.tsx
+++ b/frontend/src/components/ui/Toast.tsx
@@ -106,7 +106,11 @@ export const Toast: React.FC<ToastProps> = ({
   }));
 
   return (
-    <Animated.View style={[styles.container, animatedStyle]}>
+    <Animated.View
+      style={[styles.container, animatedStyle]}
+      accessibilityRole="alert"
+      accessibilityLiveRegion={type === "error" ? "assertive" : "polite"}
+    >
       <View
         style={[
           styles.toast,
@@ -139,6 +143,9 @@ export const Toast: React.FC<ToastProps> = ({
               handleDismiss();
             }}
             style={styles.actionButton}
+            accessibilityRole="button"
+            accessibilityLabel={action.label}
+            accessibilityHint="Performs action and dismisses notification"
           >
             <Text
               style={[
@@ -158,6 +165,9 @@ export const Toast: React.FC<ToastProps> = ({
         <TouchableOpacity
           onPress={handleDismiss}
           hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          accessibilityRole="button"
+          accessibilityLabel="Dismiss notification"
+          accessibilityHint="Closes this notification message"
         >
           <Ionicons name="close" size={20} color={config.color} />
         </TouchableOpacity>


### PR DESCRIPTION
## **User description**
💡 What: Added ARIA roles, labels, and hints to the Toast component and its action/dismiss buttons.
🎯 Why: Screen readers could not announce transient notification feedback when it appeared. The internal interactive dismiss and action buttons were also icon-only or dynamic text, lacking context and roles, effectively rendering them invisible to non-sighted users.
📸 Before/After: Visuals unchanged. Screen readers now announce the toast as an alert and can focus its internal action and dismiss buttons.
♿ Accessibility:
- Added `accessibilityRole="alert"` and `accessibilityLiveRegion` to the main Toast container.
- Added `accessibilityRole="button"`, `accessibilityLabel`, and `accessibilityHint` to the action button.
- Added `accessibilityRole="button"`, `accessibilityLabel="Dismiss notification"`, and `accessibilityHint` to the close icon button.
- Explicitly avoided `accessible={true}` on the wrapper so that children remain independently focusable by the screen reader.
- Logged findings in `.Jules/palette.md`

---
*PR created automatically by Jules for task [10636838923107020673](https://jules.google.com/task/10636838923107020673) started by @mknoufi*


___

## **CodeAnt-AI Description**
Make Toast notifications accessible to screen readers

### What Changed
- Toasts are now announced to screen readers as alerts and use an appropriate live region (errors announced assertively, info announced politely)
- Action buttons inside toasts expose a button role, an explicit label, and a hint so screen reader users understand and can invoke the action which also dismisses the toast
- The close icon exposes a button role, a clear "Dismiss notification" label, and a hint so screen reader users can reliably close the toast

### Impact
`✅ Screen readers announce toast messages`
`✅ Screen reader users can invoke toast actions and dismissals`
`✅ Critical error messages are announced immediately`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
