### PR TITLE
🎨 Palette: Add accessibility props to custom Checkbox and Radio components

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-28 - Icon-Only Button Accessibility in Search
 **Learning:** Icon-only action buttons (like scan barcode, voice search, and submit inputs) are completely inaccessible to screen reader users if missing proper accessibility props, as they provide no context about their function.
 **Action:** Always add `accessibilityRole="button"` and an explicit `accessibilityLabel` (e.g., "Scan barcode with camera") to icon-only `TouchableOpacity` elements, along with `accessibilityState` for dynamic states like disabled or checked.
+
+## 2024-05-24 - Checkbox and Radio Accessibility
+**Learning:** Custom UI components like `Checkbox` and `Radio` often miss default accessibility behaviors found in native components (role, state, label) when built with `TouchableOpacity`.
+**Action:** Always verify custom interactive components expose `accessibilityRole`, `accessibilityState`, and `accessibilityLabel` props.

--- a/frontend/src/components/ui/Checkbox.tsx
+++ b/frontend/src/components/ui/Checkbox.tsx
@@ -7,11 +7,7 @@
 import React from "react";
 import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withSpring,
-} from "react-native-reanimated";
+import Animated, { useSharedValue, useAnimatedStyle, withSpring } from "react-native-reanimated";
 import {
   colorPalette,
   spacing,
@@ -62,6 +58,9 @@ export const Checkbox: React.FC<CheckboxProps> = ({
       onPress={handlePress}
       disabled={disabled}
       activeOpacity={0.7}
+      accessibilityRole="checkbox"
+      accessibilityState={{ checked: checked || indeterminate, disabled }}
+      accessibilityLabel={label || description || "Checkbox"}
     >
       <View
         style={[
@@ -81,11 +80,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
 
       {(label || description) && (
         <View style={styles.labelContainer}>
-          {label && (
-            <Text style={[styles.label, disabled && styles.labelDisabled]}>
-              {label}
-            </Text>
-          )}
+          {label && <Text style={[styles.label, disabled && styles.labelDisabled]}>{label}</Text>}
 
           {description && <Text style={styles.description}>{description}</Text>}
         </View>

--- a/frontend/src/components/ui/Radio.tsx
+++ b/frontend/src/components/ui/Radio.tsx
@@ -6,17 +6,8 @@
 
 import React from "react";
 import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withSpring,
-} from "react-native-reanimated";
-import {
-  colorPalette,
-  spacing,
-  typography,
-  touchTargets,
-} from "@/theme/designTokens";
+import Animated, { useSharedValue, useAnimatedStyle, withSpring } from "react-native-reanimated";
+import { colorPalette, spacing, typography, touchTargets } from "@/theme/designTokens";
 
 export interface RadioOption {
   value: string;
@@ -32,12 +23,7 @@ interface RadioProps {
   disabled?: boolean;
 }
 
-export const Radio: React.FC<RadioProps> = ({
-  options,
-  value,
-  onChange,
-  disabled = false,
-}) => {
+export const Radio: React.FC<RadioProps> = ({ options, value, onChange, disabled = false }) => {
   return (
     <View style={styles.container}>
       {options.map((option) => (
@@ -60,12 +46,7 @@ interface RadioItemProps {
   disabled?: boolean;
 }
 
-const RadioItem: React.FC<RadioItemProps> = ({
-  option,
-  selected,
-  onSelect,
-  disabled = false,
-}) => {
+const RadioItem: React.FC<RadioItemProps> = ({ option, selected, onSelect, disabled = false }) => {
   const scale = useSharedValue(selected ? 1 : 0);
 
   React.useEffect(() => {
@@ -85,31 +66,22 @@ const RadioItem: React.FC<RadioItemProps> = ({
       onPress={onSelect}
       disabled={disabled}
       activeOpacity={0.7}
+      accessibilityRole="radio"
+      accessibilityState={{ checked: selected, disabled }}
+      accessibilityLabel={option.label}
     >
       <View
-        style={[
-          styles.radio,
-          selected && styles.radioSelected,
-          disabled && styles.radioDisabled,
-        ]}
+        style={[styles.radio, selected && styles.radioSelected, disabled && styles.radioDisabled]}
       >
         <Animated.View
-          style={[
-            styles.radioInner,
-            selected && styles.radioInnerSelected,
-            innerCircleStyle,
-          ]}
+          style={[styles.radioInner, selected && styles.radioInnerSelected, innerCircleStyle]}
         />
       </View>
 
       <View style={styles.labelContainer}>
-        <Text style={[styles.label, disabled && styles.labelDisabled]}>
-          {option.label}
-        </Text>
+        <Text style={[styles.label, disabled && styles.labelDisabled]}>{option.label}</Text>
 
-        {option.description && (
-          <Text style={styles.description}>{option.description}</Text>
-        )}
+        {option.description && <Text style={styles.description}>{option.description}</Text>}
       </View>
     </TouchableOpacity>
   );


### PR DESCRIPTION
## **User description**
- 💡 **What**: Added `accessibilityRole`, `accessibilityState`, and `accessibilityLabel` to the custom `Checkbox` and `Radio` UI components.
- 🎯 **Why**: Both components use `TouchableOpacity` to create custom selection controls. Without explicitly defining their role and state, screen readers could not properly identify them as selection controls or announce their current states (`checked`, `disabled`), rendering them inaccessible to users relying on assistive technologies.
- ♿ **Accessibility**: Improved screen reader support by providing explicit native roles (`checkbox`, `radio`), states (`checked`, `disabled`), and corresponding labels for custom UI interactive elements. Also logged this learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [13812779022807098898](https://jules.google.com/task/13812779022807098898) started by @mknoufi*


___

## **CodeAnt-AI Description**
**Make custom checkbox and radio controls work properly with screen readers**

### What Changed
- Custom checkbox and radio controls now announce their role, checked state, and disabled state to screen readers
- Each control now uses its visible label as the spoken label, so users hear a clear name instead of an unlabeled control
- Checkbox also falls back to a simple generic label when no visible text is provided

### Impact
`✅ Clearer screen reader feedback`
`✅ Accessible custom selection controls`
`✅ Fewer unlabeled form controls`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
