### PR TITLE
🎨 Palette: Add accessibility labels to AppHeader icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-28 - Icon-Only Button Accessibility in Search
 **Learning:** Icon-only action buttons (like scan barcode, voice search, and submit inputs) are completely inaccessible to screen reader users if missing proper accessibility props, as they provide no context about their function.
 **Action:** Always add `accessibilityRole="button"` and an explicit `accessibilityLabel` (e.g., "Scan barcode with camera") to icon-only `TouchableOpacity` elements, along with `accessibilityState` for dynamic states like disabled or checked.
+
+## 2024-05-23 - AppHeader Icon-only Button Accessibility
+**Learning:** Key navigation and utility buttons in headers (like Settings, Notifications, Logout, Back) are often implemented as icon-only `Pressable` or `TouchableOpacity` elements. Without explicit accessibility props, screen reader users have no context for these actions.
+**Action:** Always add explicit `accessibilityRole="button"`, `accessibilityLabel` (e.g., "Settings"), and `accessibilityHint` to icon-only navigation elements in critical structural areas like headers.

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -101,17 +101,34 @@ export function AppHeader({
 
           {/* RIGHT: Actions */}
           <View style={styles.actions}>
-            <Pressable onPress={handleNotifications} style={styles.iconButton} hitSlop={10}>
+            <Pressable
+              onPress={handleNotifications}
+              style={styles.iconButton}
+              hitSlop={10}
+              accessibilityRole="button"
+              accessibilityLabel="Notifications"
+              accessibilityHint="Opens your notifications"
+            >
               <Ionicons name="notifications-outline" size={20} color={COLORS.TEXT_SECONDARY} />
               <View style={styles.badgeDot} />
             </Pressable>
-            <Pressable onPress={handleSettings} style={styles.iconButton} hitSlop={10}>
+            <Pressable
+              onPress={handleSettings}
+              style={styles.iconButton}
+              hitSlop={10}
+              accessibilityRole="button"
+              accessibilityLabel="Settings"
+              accessibilityHint="Opens application settings"
+            >
               <Ionicons name="settings-outline" size={20} color={COLORS.TEXT_SECONDARY} />
             </Pressable>
             <Pressable
               onPress={handleLogout}
               style={[styles.iconButton, { borderColor: COLORS.ERROR }]}
               hitSlop={10}
+              accessibilityRole="button"
+              accessibilityLabel="Logout"
+              accessibilityHint="Logs you out of the application"
             >
               <Ionicons name="power-outline" size={20} color={COLORS.ERROR} />
             </Pressable>
@@ -124,6 +141,9 @@ export function AppHeader({
               <TouchableOpacity
                 onPress={() => navigation.goBack()}
                 style={styles.backBtn}
+                accessibilityRole="button"
+                accessibilityLabel="Go back"
+                accessibilityHint="Returns to the previous screen"
               >
                 <Ionicons name="arrow-back" size={24} color={COLORS.TEXT_PRIMARY} />
                 <Text style={styles.backText}>Back</Text>
@@ -136,7 +156,14 @@ export function AppHeader({
           </View>
           {/* Notifications on sub-screens */}
           <View style={styles.actions}>
-            <Pressable onPress={handleNotifications} style={styles.iconButton} hitSlop={10}>
+            <Pressable
+              onPress={handleNotifications}
+              style={styles.iconButton}
+              hitSlop={10}
+              accessibilityRole="button"
+              accessibilityLabel="Notifications"
+              accessibilityHint="Opens your notifications"
+            >
               <Ionicons name="notifications-outline" size={20} color={COLORS.TEXT_SECONDARY} />
               <View style={styles.badgeDot} />
             </Pressable>


### PR DESCRIPTION
## **User description**
💡 What: Added `accessibilityRole="button"`, `accessibilityLabel`, and `accessibilityHint` properties to all icon-only action buttons (`Notifications`, `Settings`, `Logout`, `Back`) inside `AppHeader.tsx`. Also added a learning entry to `.Jules/palette.md`.

🎯 Why: Icon-only buttons implemented using `Pressable` or `TouchableOpacity` are completely inaccessible to screen reader users as they have no internal text content to announce their purpose. By explicitly defining the `accessibilityRole` and `accessibilityLabel`, users utilizing assistive technologies like VoiceOver or TalkBack can now understand and interact with the primary header actions.

📸 Before/After: N/A - The changes are purely semantic and non-visual.

♿ Accessibility:
- Added `accessibilityRole="button"` to ensure screen readers announce these elements as interactive buttons.
- Added descriptive `accessibilityLabel` (e.g., "Settings", "Notifications") to identify the buttons.
- Added descriptive `accessibilityHint` to provide additional context on what the action will do.

---
*PR created automatically by Jules for task [6563730310490271569](https://jules.google.com/task/6563730310490271569) started by @mknoufi*


___

## **CodeAnt-AI Description**
**Make header icon buttons readable to screen readers**

### What Changed
- Header action icons now announce themselves as buttons with clear labels and hints for Notifications, Settings, Logout, and Back
- The back button now tells assistive technology users that it returns to the previous screen
- These accessibility details were added in both the main header and sub-screen header layouts

### Impact
`✅ Screen reader access to header actions`
`✅ Clearer navigation for VoiceOver and TalkBack users`
`✅ Fewer unlabeled buttons in the app header`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
