### PR TITLE
🎨 Palette: Add accessibility attributes to Checkbox and Radio components

### DIFF
--- a/frontend/src/components/ui/Checkbox.tsx
+++ b/frontend/src/components/ui/Checkbox.tsx
@@ -7,11 +7,7 @@
 import React from "react";
 import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withSpring,
-} from "react-native-reanimated";
+import Animated, { useSharedValue, useAnimatedStyle, withSpring } from "react-native-reanimated";
 import {
   colorPalette,
   spacing,
@@ -27,6 +23,7 @@ interface CheckboxProps {
   description?: string;
   disabled?: boolean;
   indeterminate?: boolean;
+  accessibilityLabel?: string;
 }
 
 export const Checkbox: React.FC<CheckboxProps> = ({
@@ -36,6 +33,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   description,
   disabled = false,
   indeterminate = false,
+  accessibilityLabel,
 }) => {
   const scale = useSharedValue(checked || indeterminate ? 1 : 0);
 
@@ -62,6 +60,9 @@ export const Checkbox: React.FC<CheckboxProps> = ({
       onPress={handlePress}
       disabled={disabled}
       activeOpacity={0.7}
+      accessibilityRole="checkbox"
+      accessibilityState={{ checked: indeterminate ? "mixed" : checked, disabled }}
+      accessibilityLabel={accessibilityLabel || label || "Checkbox"}
     >
       <View
         style={[
@@ -81,11 +82,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
 
       {(label || description) && (
         <View style={styles.labelContainer}>
-          {label && (
-            <Text style={[styles.label, disabled && styles.labelDisabled]}>
-              {label}
-            </Text>
-          )}
+          {label && <Text style={[styles.label, disabled && styles.labelDisabled]}>{label}</Text>}
 
           {description && <Text style={styles.description}>{description}</Text>}
         </View>

--- a/frontend/src/components/ui/Radio.tsx
+++ b/frontend/src/components/ui/Radio.tsx
@@ -6,23 +6,15 @@
 
 import React from "react";
 import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withSpring,
-} from "react-native-reanimated";
-import {
-  colorPalette,
-  spacing,
-  typography,
-  touchTargets,
-} from "@/theme/designTokens";
+import Animated, { useSharedValue, useAnimatedStyle, withSpring } from "react-native-reanimated";
+import { colorPalette, spacing, typography, touchTargets } from "@/theme/designTokens";
 
 export interface RadioOption {
   value: string;
   label: string;
   description?: string;
   disabled?: boolean;
+  accessibilityLabel?: string;
 }
 
 interface RadioProps {
@@ -32,12 +24,7 @@ interface RadioProps {
   disabled?: boolean;
 }
 
-export const Radio: React.FC<RadioProps> = ({
-  options,
-  value,
-  onChange,
-  disabled = false,
-}) => {
+export const Radio: React.FC<RadioProps> = ({ options, value, onChange, disabled = false }) => {
   return (
     <View style={styles.container}>
       {options.map((option) => (
@@ -60,12 +47,7 @@ interface RadioItemProps {
   disabled?: boolean;
 }
 
-const RadioItem: React.FC<RadioItemProps> = ({
-  option,
-  selected,
-  onSelect,
-  disabled = false,
-}) => {
+const RadioItem: React.FC<RadioItemProps> = ({ option, selected, onSelect, disabled = false }) => {
   const scale = useSharedValue(selected ? 1 : 0);
 
   React.useEffect(() => {
@@ -85,31 +67,22 @@ const RadioItem: React.FC<RadioItemProps> = ({
       onPress={onSelect}
       disabled={disabled}
       activeOpacity={0.7}
+      accessibilityRole="radio"
+      accessibilityState={{ checked: selected, disabled }}
+      accessibilityLabel={option.accessibilityLabel || option.label || "Radio button"}
     >
       <View
-        style={[
-          styles.radio,
-          selected && styles.radioSelected,
-          disabled && styles.radioDisabled,
-        ]}
+        style={[styles.radio, selected && styles.radioSelected, disabled && styles.radioDisabled]}
       >
         <Animated.View
-          style={[
-            styles.radioInner,
-            selected && styles.radioInnerSelected,
-            innerCircleStyle,
-          ]}
+          style={[styles.radioInner, selected && styles.radioInnerSelected, innerCircleStyle]}
         />
       </View>
 
       <View style={styles.labelContainer}>
-        <Text style={[styles.label, disabled && styles.labelDisabled]}>
-          {option.label}
-        </Text>
+        <Text style={[styles.label, disabled && styles.labelDisabled]}>{option.label}</Text>
 
-        {option.description && (
-          <Text style={styles.description}>{option.description}</Text>
-        )}
+        {option.description && <Text style={styles.description}>{option.description}</Text>}
       </View>
     </TouchableOpacity>
   );


### PR DESCRIPTION
## **User description**
💡 **What:** Added missing explicit accessibility roles (`checkbox`, `radio`), states (`checked`, `mixed`, `disabled`), and labels to the `Checkbox` and `Radio` components.

🎯 **Why:** Custom form controls implemented via `TouchableOpacity` are completely opaque to screen readers without explicit ARIA/accessibility attributes. These changes ensure assistive technologies announce their purpose and current selected state.

♿ **Accessibility:** Users navigating via screen reader will now properly understand that they are interacting with toggleable form inputs, along with their checked/unchecked and disabled states.

---
*PR created automatically by Jules for task [2106755711524750357](https://jules.google.com/task/2106755711524750357) started by @mknoufi*


___

## **CodeAnt-AI Description**
Add screen reader support to checkbox and radio controls

### What Changed
- Checkbox and radio items now announce their purpose, selected state, and disabled state to screen readers
- Checkbox supports an explicit label for accessibility, including mixed state for indeterminate selections
- Radio options can use a custom accessibility label when the visible label is not enough

### Impact
`✅ Clearer screen reader announcements`
`✅ Easier form navigation with assistive tech`
`✅ Fewer confusing toggle states`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
