### PR TITLE
🎨 Palette: Add accessibility states to custom buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-28 - Icon-Only Button Accessibility in Search
 **Learning:** Icon-only action buttons (like scan barcode, voice search, and submit inputs) are completely inaccessible to screen reader users if missing proper accessibility props, as they provide no context about their function.
 **Action:** Always add `accessibilityRole="button"` and an explicit `accessibilityLabel` (e.g., "Scan barcode with camera") to icon-only `TouchableOpacity` elements, along with `accessibilityState` for dynamic states like disabled or checked.
+
+## 2026-04-10 - Custom Button Disabled/Loading States Accessibility
+**Learning:** Custom generic button components (like `Button` or `RippleButton`) that wrap `TouchableOpacity` must explicitly map their internal `disabled` and `loading` props to `accessibilityState={{ disabled: boolean, busy: boolean }}`. Otherwise, screen reader users will not be announced when the button is inactive or processing an action.
+**Action:** Always ensure that custom wrapper components for interactable elements explicitly forward or compute the `accessibilityState` prop to the root native element.

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode } from "react";
 import {
   TouchableOpacity,
   Text,
@@ -7,21 +7,35 @@ import {
   TextStyle,
   GestureResponderEvent,
   ActivityIndicator,
-} from 'react-native';
+} from "react-native";
 
 interface ButtonProps {
   title: string;
   onPress: (event: GestureResponderEvent) => void;
-  variant?: 'primary' | 'secondary' | 'danger' | 'ghost';
-  size?: 'small' | 'medium' | 'large';
+  variant?: "primary" | "secondary" | "danger" | "ghost";
+  size?: "small" | "medium" | "large";
   disabled?: boolean;
   loading?: boolean;
   icon?: ReactNode;
-  iconPosition?: 'left' | 'right';
+  iconPosition?: "left" | "right";
   fullWidth?: boolean;
   style?: StyleProp<ViewStyle>;
   textStyle?: StyleProp<TextStyle>;
   testID?: string;
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
+  accessibilityRole?:
+    | "none"
+    | "button"
+    | "link"
+    | "search"
+    | "image"
+    | "keyboardkey"
+    | "text"
+    | "adjustable"
+    | "imagebutton"
+    | "header"
+    | "summary";
 }
 
 const sizeMap = {
@@ -31,47 +45,50 @@ const sizeMap = {
 } as const;
 
 const variantColors = {
-  primary: { bg: '#007AFF', text: '#FFFFFF' },
-  secondary: { bg: '#E5E5E5', text: '#000000' },
-  danger: { bg: '#FF3B30', text: '#FFFFFF' },
-  ghost: { bg: 'transparent', text: '#007AFF' },
+  primary: { bg: "#007AFF", text: "#FFFFFF" },
+  secondary: { bg: "#E5E5E5", text: "#000000" },
+  danger: { bg: "#FF3B30", text: "#FFFFFF" },
+  ghost: { bg: "transparent", text: "#007AFF" },
 } as const;
 
 export const Button: React.FC<ButtonProps> = ({
   title,
   onPress,
-  variant = 'primary',
-  size = 'medium',
+  variant = "primary",
+  size = "medium",
   disabled = false,
   loading = false,
   icon,
-  iconPosition = 'left',
+  iconPosition = "left",
   fullWidth = false,
   style,
   textStyle,
   testID,
+  accessibilityLabel,
+  accessibilityHint,
+  accessibilityRole,
 }) => {
   const isDisabled = disabled || loading;
   const sizeStyles = sizeMap[size];
   const colors = variantColors[variant];
 
   const buttonStyles: ViewStyle = {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
     backgroundColor: colors.bg,
     paddingVertical: sizeStyles.paddingVertical,
     paddingHorizontal: sizeStyles.paddingHorizontal,
     borderRadius: 8,
     opacity: isDisabled ? 0.5 : 1,
-    ...(fullWidth && { width: '100%' }),
-    ...(variant === 'ghost' && { borderWidth: 1, borderColor: colors.text }),
+    ...(fullWidth && { width: "100%" }),
+    ...(variant === "ghost" && { borderWidth: 1, borderColor: colors.text }),
   };
 
   const textStyles: TextStyle = {
     color: colors.text,
     fontSize: sizeStyles.fontSize,
-    fontWeight: '600',
+    fontWeight: "600",
     marginHorizontal: icon ? 4 : 0,
   };
 
@@ -82,14 +99,18 @@ export const Button: React.FC<ButtonProps> = ({
       disabled={isDisabled}
       testID={testID}
       activeOpacity={0.7}
+      accessibilityRole={accessibilityRole || "button"}
+      accessibilityLabel={accessibilityLabel || title}
+      accessibilityHint={accessibilityHint}
+      accessibilityState={{ disabled: isDisabled, busy: loading }}
     >
       {loading ? (
         <ActivityIndicator color={colors.text} size="small" />
       ) : (
         <>
-          {icon && iconPosition === 'left' && icon}
+          {icon && iconPosition === "left" && icon}
           <Text style={[textStyles, textStyle]}>{title}</Text>
-          {icon && iconPosition === 'right' && icon}
+          {icon && iconPosition === "right" && icon}
         </>
       )}
     </TouchableOpacity>

--- a/frontend/src/components/ui/RippleButton.tsx
+++ b/frontend/src/components/ui/RippleButton.tsx
@@ -58,6 +58,20 @@ interface RippleButtonProps {
   style?: ViewStyle;
   textStyle?: TextStyle;
   hapticFeedback?: "light" | "medium" | "heavy" | "none";
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
+  accessibilityRole?:
+    | "none"
+    | "button"
+    | "link"
+    | "search"
+    | "image"
+    | "keyboardkey"
+    | "text"
+    | "adjustable"
+    | "imagebutton"
+    | "header"
+    | "summary";
 }
 
 const variantStyles = {
@@ -82,10 +96,7 @@ const variantStyles = {
     rippleColor: "rgba(255, 255, 255, 0.3)",
   },
   error: {
-    gradient: [
-      auroraTheme.colors.error[500],
-      auroraTheme.colors.error[700],
-    ] as const,
+    gradient: [auroraTheme.colors.error[500], auroraTheme.colors.error[700]] as const,
     textColor: auroraTheme.colors.text.primary,
     rippleColor: "rgba(255, 255, 255, 0.3)",
   },
@@ -146,6 +157,9 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
   style,
   textStyle,
   hapticFeedback = "medium",
+  accessibilityLabel,
+  accessibilityHint,
+  accessibilityRole,
 }) => {
   const [buttonLayout, setButtonLayout] = useState({ width: 0, height: 0 });
   const rippleScale = useSharedValue(0);
@@ -169,7 +183,7 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
     // Calculate max ripple size
     const maxDistance = Math.sqrt(
       Math.pow(Math.max(locationX, buttonLayout.width - locationX), 2) +
-      Math.pow(Math.max(locationY, buttonLayout.height - locationY), 2),
+        Math.pow(Math.max(locationY, buttonLayout.height - locationY), 2)
     );
     const maxScale = (maxDistance * 2) / 10; // 10 is base ripple size
 
@@ -255,11 +269,7 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
 
       {/* Ripple effect */}
       <Animated.View
-        style={[
-          styles.ripple,
-          { backgroundColor: variantStyle.rippleColor },
-          rippleStyle,
-        ]}
+        style={[styles.ripple, { backgroundColor: variantStyle.rippleColor }, rippleStyle]}
         pointerEvents="none"
       />
     </>
@@ -276,12 +286,15 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
     fullWidth ? styles.fullWidth : {},
     variant === "outline"
       ? {
-        borderWidth: 2,
-        borderColor: auroraTheme.colors.primary[400],
-      }
+          borderWidth: 2,
+          borderColor: auroraTheme.colors.primary[400],
+        }
       : {},
     style ?? {},
   ];
+
+  const a11yLabel =
+    accessibilityLabel || label || (typeof children === "string" ? children : undefined);
 
   if (variant === "ghost" || variant === "outline") {
     return (
@@ -291,6 +304,10 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
         onLayout={handleLayout}
         disabled={disabled || loading}
         activeOpacity={0.8}
+        accessibilityRole={accessibilityRole || "button"}
+        accessibilityLabel={a11yLabel}
+        accessibilityHint={accessibilityHint}
+        accessibilityState={{ disabled: disabled || loading, busy: loading }}
       >
         {content}
       </TouchableOpacity>
@@ -304,6 +321,10 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
       disabled={disabled || loading}
       activeOpacity={0.9}
       style={[fullWidth && styles.fullWidth]}
+      accessibilityRole={accessibilityRole || "button"}
+      accessibilityLabel={a11yLabel}
+      accessibilityHint={accessibilityHint}
+      accessibilityState={{ disabled: disabled || loading, busy: loading }}
     >
       <LinearGradient
         colors={variantStyle.gradient as readonly [string, string, ...string[]]}


### PR DESCRIPTION
## **User description**
💡 What: Added `accessibilityRole`, `accessibilityLabel`, `accessibilityHint`, and most critically, `accessibilityState` props to the custom `Button` and `RippleButton` UI components. 
🎯 Why: Custom button wrappers that use `TouchableOpacity` do not automatically announce their internal `disabled` or `loading` states to screen readers. By explicitly mapping these states to `accessibilityState`, we ensure these generic action buttons provide proper context when interacted with using a screen reader. 
♿ Accessibility: Ensures that `Button` and `RippleButton` announce their active, disabled, or loading (busy) states accurately via `accessibilityState`. Also exposes `accessibilityLabel` and `accessibilityHint` props for further customizability.

---
*PR created automatically by Jules for task [12285185566273764095](https://jules.google.com/task/12285185566273764095) started by @mknoufi*


___

## **CodeAnt-AI Description**
**Make custom buttons announce disabled and loading states to screen readers**

### What Changed
- Custom buttons now announce when they are disabled or loading, so screen reader users can tell when an action is unavailable or in progress
- Button and RippleButton now accept clearer accessibility label, hint, and role text for more understandable button announcements
- Buttons keep using the visible title or label as the spoken name when no custom label is provided

### Impact
`✅ Clearer screen reader feedback`
`✅ Fewer accidental taps on unavailable actions`
`✅ Better accessibility for loading buttons`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
