### PR TITLE
🎨 Palette: Improve Accessibility of Accordion Component

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-28 - Icon-Only Button Accessibility in Search
 **Learning:** Icon-only action buttons (like scan barcode, voice search, and submit inputs) are completely inaccessible to screen reader users if missing proper accessibility props, as they provide no context about their function.
 **Action:** Always add `accessibilityRole="button"` and an explicit `accessibilityLabel` (e.g., "Scan barcode with camera") to icon-only `TouchableOpacity` elements, along with `accessibilityState` for dynamic states like disabled or checked.
+
+## 2026-02-28 - Expandable Section Accessibility
+**Learning:** Custom expandable components built with generic containers like `TouchableOpacity` don't announce their state changes to screen readers by default. This makes it impossible for visually impaired users to know if a section is open or closed.
+**Action:** Always verify custom expandable sections explicitly include `accessibilityRole="button"`, an `accessibilityState={{ expanded: boolean }}`, and descriptive `accessibilityLabel` and `accessibilityHint` props.

--- a/frontend/src/components/ui/Accordion.tsx
+++ b/frontend/src/components/ui/Accordion.tsx
@@ -15,24 +15,11 @@ import {
   UIManager,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withTiming,
-} from "react-native-reanimated";
-import {
-  colorPalette,
-  spacing,
-  typography,
-  borderRadius,
-  shadows,
-} from "@/theme/designTokens";
+import Animated, { useSharedValue, useAnimatedStyle, withTiming } from "react-native-reanimated";
+import { colorPalette, spacing, typography, borderRadius, shadows } from "@/theme/designTokens";
 
 // Enable LayoutAnimation on Android
-if (
-  Platform.OS === "android" &&
-  UIManager.setLayoutAnimationEnabledExperimental
-) {
+if (Platform.OS === "android" && UIManager.setLayoutAnimationEnabledExperimental) {
   UIManager.setLayoutAnimationEnabledExperimental(true);
 }
 
@@ -56,9 +43,7 @@ export const Accordion: React.FC<AccordionProps> = ({
   defaultExpanded = [],
   onItemToggle,
 }) => {
-  const [expandedItems, setExpandedItems] = useState<Set<string>>(
-    new Set(defaultExpanded),
-  );
+  const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set(defaultExpanded));
 
   const toggleItem = (id: string) => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
@@ -129,6 +114,10 @@ const AccordionItemComponent: React.FC<AccordionItemComponentProps> = ({
         style={styles.header}
         onPress={onToggle}
         activeOpacity={0.7}
+        accessibilityRole="button"
+        accessibilityState={{ expanded: isExpanded }}
+        accessibilityLabel={item.title}
+        accessibilityHint="Toggles the section content"
       >
         {item.icon && (
           <Ionicons
@@ -142,11 +131,7 @@ const AccordionItemComponent: React.FC<AccordionItemComponentProps> = ({
         <Text style={styles.title}>{item.title}</Text>
 
         <Animated.View style={iconStyle}>
-          <Ionicons
-            name="chevron-down"
-            size={20}
-            color={colorPalette.neutral[600]}
-          />
+          <Ionicons name="chevron-down" size={20} color={colorPalette.neutral[600]} />
         </Animated.View>
       </TouchableOpacity>
 


### PR DESCRIPTION
## **User description**
💡 What: Added `accessibilityRole`, `accessibilityState={{ expanded }}`, `accessibilityLabel`, and `accessibilityHint` to the `Accordion` component's header.
🎯 Why: Generic `TouchableOpacity` wrappers don't announce their state changes to screen readers by default. This change ensures visually impaired users know they are interacting with an expandable section and whether it is currently open or closed.
♿ Accessibility: Ensures custom expandable sections are fully compatible with screen readers.

---
*PR created automatically by Jules for task [17238449196136710385](https://jules.google.com/task/17238449196136710385) started by @mknoufi*


___

## **CodeAnt-AI Description**
Make accordion sections easier to use with screen readers

### What Changed
- Accordion headers now announce as buttons with their open or closed state
- Each section header now includes a clear label and hint so screen reader users know it expands content
- The accordion’s open/close behavior remains the same for sighted users

### Impact
`✅ Clearer screen reader navigation`
`✅ Easier to tell when a section is expanded`
`✅ More accessible expandable sections`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
