### PR TITLE
🎨 Palette: Enhance accessibility props for custom Button components

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-28 - Icon-Only Button Accessibility in Search
 **Learning:** Icon-only action buttons (like scan barcode, voice search, and submit inputs) are completely inaccessible to screen reader users if missing proper accessibility props, as they provide no context about their function.
 **Action:** Always add `accessibilityRole="button"` and an explicit `accessibilityLabel` (e.g., "Scan barcode with camera") to icon-only `TouchableOpacity` elements, along with `accessibilityState` for dynamic states like disabled or checked.
+
+## 2026-02-28 - Custom Buttons wrapped in TouchableOpacity
+**Learning:** Custom UI buttons that wrap interactive elements like `TouchableOpacity` often fail to properly communicate their states (like busy or disabled) to screen readers because `accessibilityState` isn't dynamically constructed and passed down. Additionally, missing explicitly set roles (`accessibilityRole="button"`) can cause inconsistencies in how they are announced.
+**Action:** Always ensure that any generic/custom UI wrapper component around `TouchableOpacity` defines, populates, and correctly passes down `accessibilityRole`, `accessibilityLabel`, `accessibilityHint`, and a dynamic `accessibilityState` object (accounting for `disabled` and `busy` states).

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode } from "react";
 import {
   TouchableOpacity,
   Text,
@@ -7,21 +7,24 @@ import {
   TextStyle,
   GestureResponderEvent,
   ActivityIndicator,
-} from 'react-native';
+} from "react-native";
 
 interface ButtonProps {
   title: string;
   onPress: (event: GestureResponderEvent) => void;
-  variant?: 'primary' | 'secondary' | 'danger' | 'ghost';
-  size?: 'small' | 'medium' | 'large';
+  variant?: "primary" | "secondary" | "danger" | "ghost";
+  size?: "small" | "medium" | "large";
   disabled?: boolean;
   loading?: boolean;
   icon?: ReactNode;
-  iconPosition?: 'left' | 'right';
+  iconPosition?: "left" | "right";
   fullWidth?: boolean;
   style?: StyleProp<ViewStyle>;
   textStyle?: StyleProp<TextStyle>;
   testID?: string;
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
+  accessibilityRole?: "button" | "link" | "none";
 }
 
 const sizeMap = {
@@ -31,47 +34,50 @@ const sizeMap = {
 } as const;
 
 const variantColors = {
-  primary: { bg: '#007AFF', text: '#FFFFFF' },
-  secondary: { bg: '#E5E5E5', text: '#000000' },
-  danger: { bg: '#FF3B30', text: '#FFFFFF' },
-  ghost: { bg: 'transparent', text: '#007AFF' },
+  primary: { bg: "#007AFF", text: "#FFFFFF" },
+  secondary: { bg: "#E5E5E5", text: "#000000" },
+  danger: { bg: "#FF3B30", text: "#FFFFFF" },
+  ghost: { bg: "transparent", text: "#007AFF" },
 } as const;
 
 export const Button: React.FC<ButtonProps> = ({
   title,
   onPress,
-  variant = 'primary',
-  size = 'medium',
+  variant = "primary",
+  size = "medium",
   disabled = false,
   loading = false,
   icon,
-  iconPosition = 'left',
+  iconPosition = "left",
   fullWidth = false,
   style,
   textStyle,
   testID,
+  accessibilityLabel,
+  accessibilityHint,
+  accessibilityRole,
 }) => {
   const isDisabled = disabled || loading;
   const sizeStyles = sizeMap[size];
   const colors = variantColors[variant];
 
   const buttonStyles: ViewStyle = {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
     backgroundColor: colors.bg,
     paddingVertical: sizeStyles.paddingVertical,
     paddingHorizontal: sizeStyles.paddingHorizontal,
     borderRadius: 8,
     opacity: isDisabled ? 0.5 : 1,
-    ...(fullWidth && { width: '100%' }),
-    ...(variant === 'ghost' && { borderWidth: 1, borderColor: colors.text }),
+    ...(fullWidth && { width: "100%" }),
+    ...(variant === "ghost" && { borderWidth: 1, borderColor: colors.text }),
   };
 
   const textStyles: TextStyle = {
     color: colors.text,
     fontSize: sizeStyles.fontSize,
-    fontWeight: '600',
+    fontWeight: "600",
     marginHorizontal: icon ? 4 : 0,
   };
 
@@ -82,14 +88,18 @@ export const Button: React.FC<ButtonProps> = ({
       disabled={isDisabled}
       testID={testID}
       activeOpacity={0.7}
+      accessibilityRole={accessibilityRole || "button"}
+      accessibilityLabel={accessibilityLabel || title}
+      accessibilityHint={accessibilityHint}
+      accessibilityState={{ disabled: isDisabled, busy: loading }}
     >
       {loading ? (
         <ActivityIndicator color={colors.text} size="small" />
       ) : (
         <>
-          {icon && iconPosition === 'left' && icon}
+          {icon && iconPosition === "left" && icon}
           <Text style={[textStyles, textStyle]}>{title}</Text>
-          {icon && iconPosition === 'right' && icon}
+          {icon && iconPosition === "right" && icon}
         </>
       )}
     </TouchableOpacity>

--- a/frontend/src/components/ui/RippleButton.tsx
+++ b/frontend/src/components/ui/RippleButton.tsx
@@ -58,6 +58,9 @@ interface RippleButtonProps {
   style?: ViewStyle;
   textStyle?: TextStyle;
   hapticFeedback?: "light" | "medium" | "heavy" | "none";
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
+  accessibilityRole?: "button" | "link" | "none";
 }
 
 const variantStyles = {
@@ -82,10 +85,7 @@ const variantStyles = {
     rippleColor: "rgba(255, 255, 255, 0.3)",
   },
   error: {
-    gradient: [
-      auroraTheme.colors.error[500],
-      auroraTheme.colors.error[700],
-    ] as const,
+    gradient: [auroraTheme.colors.error[500], auroraTheme.colors.error[700]] as const,
     textColor: auroraTheme.colors.text.primary,
     rippleColor: "rgba(255, 255, 255, 0.3)",
   },
@@ -146,6 +146,9 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
   style,
   textStyle,
   hapticFeedback = "medium",
+  accessibilityLabel,
+  accessibilityHint,
+  accessibilityRole,
 }) => {
   const [buttonLayout, setButtonLayout] = useState({ width: 0, height: 0 });
   const rippleScale = useSharedValue(0);
@@ -169,7 +172,7 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
     // Calculate max ripple size
     const maxDistance = Math.sqrt(
       Math.pow(Math.max(locationX, buttonLayout.width - locationX), 2) +
-      Math.pow(Math.max(locationY, buttonLayout.height - locationY), 2),
+        Math.pow(Math.max(locationY, buttonLayout.height - locationY), 2)
     );
     const maxScale = (maxDistance * 2) / 10; // 10 is base ripple size
 
@@ -255,11 +258,7 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
 
       {/* Ripple effect */}
       <Animated.View
-        style={[
-          styles.ripple,
-          { backgroundColor: variantStyle.rippleColor },
-          rippleStyle,
-        ]}
+        style={[styles.ripple, { backgroundColor: variantStyle.rippleColor }, rippleStyle]}
         pointerEvents="none"
       />
     </>
@@ -276,9 +275,9 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
     fullWidth ? styles.fullWidth : {},
     variant === "outline"
       ? {
-        borderWidth: 2,
-        borderColor: auroraTheme.colors.primary[400],
-      }
+          borderWidth: 2,
+          borderColor: auroraTheme.colors.primary[400],
+        }
       : {},
     style ?? {},
   ];
@@ -291,6 +290,10 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
         onLayout={handleLayout}
         disabled={disabled || loading}
         activeOpacity={0.8}
+        accessibilityRole={accessibilityRole || "button"}
+        accessibilityLabel={accessibilityLabel || label}
+        accessibilityHint={accessibilityHint}
+        accessibilityState={{ disabled: disabled || loading, busy: loading }}
       >
         {content}
       </TouchableOpacity>
@@ -304,6 +307,10 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
       disabled={disabled || loading}
       activeOpacity={0.9}
       style={[fullWidth && styles.fullWidth]}
+      accessibilityRole={accessibilityRole || "button"}
+      accessibilityLabel={accessibilityLabel || label}
+      accessibilityHint={accessibilityHint}
+      accessibilityState={{ disabled: disabled || loading, busy: loading }}
     >
       <LinearGradient
         colors={variantStyle.gradient as readonly [string, string, ...string[]]}


### PR DESCRIPTION
## **User description**
🎨 Palette: Enhance accessibility props for custom Button components

💡 What: Added explicitly passed `accessibilityRole`, `accessibilityLabel`, `accessibilityHint`, and dynamic `accessibilityState` (including `busy` and `disabled` states) to custom UI wrappers (`Button.tsx` and `RippleButton.tsx`) around `TouchableOpacity`.
🎯 Why: Custom buttons that wrap `TouchableOpacity` often fail to communicate their state to screen readers by default. Screen reader users can now accurately perceive when buttons are disabled or loading, and icon-only variants can provide meaningful context.
♿ Accessibility: Ensures `accessibilityState` (busy and disabled statuses) and semantic roles are broadcast effectively for custom button implementations.

*PR created automatically by Jules for task [5777280470140340624](https://jules.google.com/task/5777280470140340624) started by @mknoufi*


___

## **CodeAnt-AI Description**
**Improve screen reader support for custom buttons**

### What Changed
- Custom buttons now announce a button role by default and can receive a clearer label and hint for screen readers
- Buttons now report when they are disabled or loading, so assistive technology can describe unavailable or in-progress actions
- The same accessibility behavior now applies to both standard and ripple-style button variants

### Impact
`✅ Clearer screen reader button announcements`
`✅ Fewer confusing disabled or loading actions`
`✅ Better support for icon-only buttons`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=lFfQz1AKD8jsfyOrJyJ3mHY7M7wuw5i12oj_rssC1o4&org=mknoufi)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
