### PR TITLE
🎨 Palette: SpeedDialMenu accessibility improvements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-28 - Icon-Only Button Accessibility in Search
 **Learning:** Icon-only action buttons (like scan barcode, voice search, and submit inputs) are completely inaccessible to screen reader users if missing proper accessibility props, as they provide no context about their function.
 **Action:** Always add `accessibilityRole="button"` and an explicit `accessibilityLabel` (e.g., "Scan barcode with camera") to icon-only `TouchableOpacity` elements, along with `accessibilityState` for dynamic states like disabled or checked.
+
+## 2026-02-28 - Floating Action Button & Speed Dial Accessibility
+**Learning:** Speed dial menus often use a full-screen blurred backdrop for dismissal. If this backdrop lacks `accessible={true}` and an `accessibilityLabel`, screen reader users cannot perceive how to close the menu. Additionally, floating action buttons and their speed dial items must explicitly define `accessibilityRole="button"`, `accessibilityLabel`, and `accessibilityState={{ expanded: boolean }}` because they rely on custom nested views instead of native buttons.
+**Action:** Always verify floating action menus provide a labeled, accessible backdrop overlay for dismissal, and explicitly define `accessibilityRole`, `accessibilityLabel`, and `accessibilityState` on the main trigger and all submenu items.

--- a/frontend/src/components/ui/SpeedDialMenu.tsx
+++ b/frontend/src/components/ui/SpeedDialMenu.tsx
@@ -10,13 +10,7 @@
  */
 
 import React, { useState, useEffect } from "react";
-import {
-  View,
-  Text,
-  StyleSheet,
-  TouchableOpacity,
-  Platform,
-} from "react-native";
+import { View, Text, StyleSheet, TouchableOpacity, Platform } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { LinearGradient } from "expo-linear-gradient";
 import { BlurView } from "expo-blur";
@@ -67,13 +61,9 @@ const SpeedDialActionItem: React.FC<SpeedDialActionItemProps> = ({
     const translateY = interpolate(
       animationProgress.value,
       [0, 1],
-      [0, -(72 + auroraTheme.spacing.md) * (index + 1)],
+      [0, -(72 + auroraTheme.spacing.md) * (index + 1)]
     );
-    const opacity = interpolate(
-      animationProgress.value,
-      [0, 0.5, 1],
-      [0, 0.5, 1],
-    );
+    const opacity = interpolate(animationProgress.value, [0, 0.5, 1], [0, 0.5, 1]);
     const scale = interpolate(animationProgress.value, [0, 1], [0.3, 1]);
 
     return {
@@ -87,6 +77,8 @@ const SpeedDialActionItem: React.FC<SpeedDialActionItemProps> = ({
       style={[styles.actionButton, actionStyle]}
       onPress={() => onPress(action)}
       activeOpacity={0.9}
+      accessibilityRole="button"
+      accessibilityLabel={action.label}
     >
       <View style={styles.actionContent}>
         {/* Label */}
@@ -110,20 +102,13 @@ const SpeedDialActionItem: React.FC<SpeedDialActionItemProps> = ({
             colors={
               action.color
                 ? [action.color, action.color]
-                : [
-                  auroraTheme.colors.aurora.secondary[0],
-                  auroraTheme.colors.aurora.secondary[1],
-                ]
+                : [auroraTheme.colors.aurora.secondary[0], auroraTheme.colors.aurora.secondary[1]]
             }
             start={{ x: 0, y: 0 }}
             end={{ x: 1, y: 1 }}
             style={styles.iconGradient}
           >
-            <Ionicons
-              name={action.icon}
-              size={24}
-              color={auroraTheme.colors.text.primary}
-            />
+            <Ionicons name={action.icon} size={24} color={auroraTheme.colors.text.primary} />
             {action.badge !== undefined && action.badge > 0 && (
               <View style={styles.badge}>
                 <Text style={styles.badgeText}>{action.badge}</Text>
@@ -213,15 +198,14 @@ export const SpeedDialMenu: React.FC<SpeedDialMenuProps> = ({
   return (
     <>
       {/* Backdrop */}
-      <AnimatedBlurView
-        intensity={20}
-        tint="dark"
-        style={[StyleSheet.absoluteFill, backdropStyle]}
-      >
+      <AnimatedBlurView intensity={20} tint="dark" style={[StyleSheet.absoluteFill, backdropStyle]}>
         <TouchableOpacity
           style={StyleSheet.absoluteFill}
           onPress={toggleMenu}
           activeOpacity={1}
+          accessible={true}
+          accessibilityRole="button"
+          accessibilityLabel="Close menu"
         />
       </AnimatedBlurView>
 
@@ -243,6 +227,10 @@ export const SpeedDialMenu: React.FC<SpeedDialMenuProps> = ({
           style={styles.mainButton}
           onPress={toggleMenu}
           activeOpacity={0.9}
+          accessibilityRole="button"
+          accessibilityLabel="Toggle menu"
+          accessibilityHint="Expands or collapses the quick actions menu"
+          accessibilityState={{ expanded: isOpen }}
         >
           <LinearGradient
             colors={mainColor}
@@ -251,11 +239,7 @@ export const SpeedDialMenu: React.FC<SpeedDialMenuProps> = ({
             style={styles.mainGradient}
           >
             <Animated.View style={mainButtonStyle}>
-              <Ionicons
-                name={mainIcon}
-                size={32}
-                color={auroraTheme.colors.text.primary}
-              />
+              <Ionicons name={mainIcon} size={32} color={auroraTheme.colors.text.primary} />
             </Animated.View>
           </LinearGradient>
         </TouchableOpacity>


### PR DESCRIPTION
## **User description**
💡 **What:** Added comprehensive accessibility properties to the `SpeedDialMenu` component, including its main trigger button, sub-items, and the backdrop overlay. Also updated the `.Jules/palette.md` journal to document learnings about screen reader visibility for speed dial and floating action buttons.

🎯 **Why:** Speed dial menus and floating action buttons use custom nested views that require explicit accessibility attributes (`accessibilityRole`, `accessibilityLabel`, `accessibilityState`) to be readable by screen readers. Furthermore, the blurred backdrop used for dismissal lacked `accessible={true}` and an `accessibilityLabel`, meaning screen reader users could not perceive how to close the menu.

♿ **Accessibility:**
- Added `accessibilityRole="button"`, `accessibilityLabel="Toggle menu"`, `accessibilityHint="Expands or collapses the quick actions menu"`, and `accessibilityState={{ expanded: isOpen }}` to the main trigger button.
- Added `accessibilityRole="button"` and `accessibilityLabel={action.label}` to the animated speed dial item buttons.
- Added `accessible={true}`, `accessibilityRole="button"`, and `accessibilityLabel="Close menu"` to the `AnimatedBlurView` backdrop overlay to allow screen reader users to dismiss the menu.

---
*PR created automatically by Jules for task [15144239680346819102](https://jules.google.com/task/15144239680346819102) started by @mknoufi*


___

## **CodeAnt-AI Description**
**Make the speed dial menu readable and dismissible with screen readers**

### What Changed
- The main speed dial button now announces that it opens and closes the menu, and exposes whether the menu is expanded.
- Each speed dial action now has a clear spoken label so screen reader users can identify and activate the correct action.
- The full-screen blurred backdrop is now announced as a close control, giving screen reader users a way to dismiss the menu.

### Impact
`✅ Clearer screen reader navigation`
`✅ Easier menu dismissal for assistive technology users`
`✅ Fewer inaccessible floating action menus`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=Z9lVjEwSaIlQsh-kuawW2q-4S9jg8pCZ_-gKxGtk-ro&org=mknoufi)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
