### PR TITLE
🎨 Palette: Accessibility improvements for Checkbox and Radio controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-28 - Icon-Only Button Accessibility in Search
 **Learning:** Icon-only action buttons (like scan barcode, voice search, and submit inputs) are completely inaccessible to screen reader users if missing proper accessibility props, as they provide no context about their function.
 **Action:** Always add `accessibilityRole="button"` and an explicit `accessibilityLabel` (e.g., "Scan barcode with camera") to icon-only `TouchableOpacity` elements, along with `accessibilityState` for dynamic states like disabled or checked.
+
+## 2024-06-10 - Custom Checkbox and Radio Component Accessibility
+**Learning:** Custom `Checkbox` and `Radio` components built using raw `TouchableOpacity` fail to announce themselves correctly to screen readers, missing their structural role and dynamic state (checked vs unchecked).
+**Action:** Always add `accessibilityRole="checkbox"` (or `"radio"`), `accessibilityState={{ checked, disabled }}`, and ensure an `accessibilityLabel` is provided (using the visual label as a fallback) to ensure screen reader users can interact with custom form controls.

--- a/frontend/src/components/ui/Checkbox.tsx
+++ b/frontend/src/components/ui/Checkbox.tsx
@@ -7,11 +7,7 @@
 import React from "react";
 import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withSpring,
-} from "react-native-reanimated";
+import Animated, { useSharedValue, useAnimatedStyle, withSpring } from "react-native-reanimated";
 import {
   colorPalette,
   spacing,
@@ -27,6 +23,8 @@ interface CheckboxProps {
   description?: string;
   disabled?: boolean;
   indeterminate?: boolean;
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
 }
 
 export const Checkbox: React.FC<CheckboxProps> = ({
@@ -36,6 +34,8 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   description,
   disabled = false,
   indeterminate = false,
+  accessibilityLabel,
+  accessibilityHint,
 }) => {
   const scale = useSharedValue(checked || indeterminate ? 1 : 0);
 
@@ -62,6 +62,10 @@ export const Checkbox: React.FC<CheckboxProps> = ({
       onPress={handlePress}
       disabled={disabled}
       activeOpacity={0.7}
+      accessibilityRole="checkbox"
+      accessibilityState={{ checked: checked || indeterminate, disabled }}
+      accessibilityLabel={accessibilityLabel || label || "Checkbox"}
+      accessibilityHint={accessibilityHint}
     >
       <View
         style={[
@@ -81,11 +85,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
 
       {(label || description) && (
         <View style={styles.labelContainer}>
-          {label && (
-            <Text style={[styles.label, disabled && styles.labelDisabled]}>
-              {label}
-            </Text>
-          )}
+          {label && <Text style={[styles.label, disabled && styles.labelDisabled]}>{label}</Text>}
 
           {description && <Text style={styles.description}>{description}</Text>}
         </View>

--- a/frontend/src/components/ui/Radio.tsx
+++ b/frontend/src/components/ui/Radio.tsx
@@ -6,23 +6,16 @@
 
 import React from "react";
 import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withSpring,
-} from "react-native-reanimated";
-import {
-  colorPalette,
-  spacing,
-  typography,
-  touchTargets,
-} from "@/theme/designTokens";
+import Animated, { useSharedValue, useAnimatedStyle, withSpring } from "react-native-reanimated";
+import { colorPalette, spacing, typography, touchTargets } from "@/theme/designTokens";
 
 export interface RadioOption {
   value: string;
   label: string;
   description?: string;
   disabled?: boolean;
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
 }
 
 interface RadioProps {
@@ -32,12 +25,7 @@ interface RadioProps {
   disabled?: boolean;
 }
 
-export const Radio: React.FC<RadioProps> = ({
-  options,
-  value,
-  onChange,
-  disabled = false,
-}) => {
+export const Radio: React.FC<RadioProps> = ({ options, value, onChange, disabled = false }) => {
   return (
     <View style={styles.container}>
       {options.map((option) => (
@@ -60,12 +48,7 @@ interface RadioItemProps {
   disabled?: boolean;
 }
 
-const RadioItem: React.FC<RadioItemProps> = ({
-  option,
-  selected,
-  onSelect,
-  disabled = false,
-}) => {
+const RadioItem: React.FC<RadioItemProps> = ({ option, selected, onSelect, disabled = false }) => {
   const scale = useSharedValue(selected ? 1 : 0);
 
   React.useEffect(() => {
@@ -85,31 +68,23 @@ const RadioItem: React.FC<RadioItemProps> = ({
       onPress={onSelect}
       disabled={disabled}
       activeOpacity={0.7}
+      accessibilityRole="radio"
+      accessibilityState={{ checked: selected, disabled }}
+      accessibilityLabel={option.accessibilityLabel || option.label || "Radio option"}
+      accessibilityHint={option.accessibilityHint}
     >
       <View
-        style={[
-          styles.radio,
-          selected && styles.radioSelected,
-          disabled && styles.radioDisabled,
-        ]}
+        style={[styles.radio, selected && styles.radioSelected, disabled && styles.radioDisabled]}
       >
         <Animated.View
-          style={[
-            styles.radioInner,
-            selected && styles.radioInnerSelected,
-            innerCircleStyle,
-          ]}
+          style={[styles.radioInner, selected && styles.radioInnerSelected, innerCircleStyle]}
         />
       </View>
 
       <View style={styles.labelContainer}>
-        <Text style={[styles.label, disabled && styles.labelDisabled]}>
-          {option.label}
-        </Text>
+        <Text style={[styles.label, disabled && styles.labelDisabled]}>{option.label}</Text>
 
-        {option.description && (
-          <Text style={styles.description}>{option.description}</Text>
-        )}
+        {option.description && <Text style={styles.description}>{option.description}</Text>}
       </View>
     </TouchableOpacity>
   );


### PR DESCRIPTION
## **User description**
🎨 Palette: Accessibility improvements for Checkbox and Radio controls

**💡 What:** 
Added explicit `accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` props to the custom `Checkbox` and `Radio` components in the design system.

**🎯 Why:**
These custom components were built using a generic `TouchableOpacity`, which provides no semantic meaning or state context to screen readers out of the box. By explicitly identifying them as checkboxes/radios and tracking their state (`checked`, `disabled`), screen reader users can now successfully navigate and interact with forms that use these controls.

**♿ Accessibility:**
- Added `accessibilityRole="checkbox"` to `Checkbox.tsx`.
- Added `accessibilityRole="radio"` to `Radio.tsx`.
- Bound `accessibilityState={{ checked, disabled }}` to both controls so their active status is announced dynamically.
- Implemented pass-through support for custom `accessibilityLabel` and `accessibilityHint` props, with a safe fallback to the component's visual text label.

---
*PR created automatically by Jules for task [200396649432273131](https://jules.google.com/task/200396649432273131) started by @mknoufi*


___

## **CodeAnt-AI Description**
Make custom checkbox and radio controls readable and usable with screen readers

### What Changed
- Checkbox and radio options now announce their role and checked state correctly to screen readers
- Disabled controls are announced as disabled, so users know when they cannot be selected
- Each control can now use a custom accessibility label and hint, with the visible text used as a fallback when no label is provided

### Impact
`✅ Clearer form controls for screen reader users`
`✅ Fewer accessibility errors in custom inputs`
`✅ Easier selection of checkbox and radio options`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
