### PR TITLE
🎨 Palette: Auto-map accessibility props in Input component

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-28 - Icon-Only Button Accessibility in Search
 **Learning:** Icon-only action buttons (like scan barcode, voice search, and submit inputs) are completely inaccessible to screen reader users if missing proper accessibility props, as they provide no context about their function.
 **Action:** Always add `accessibilityRole="button"` and an explicit `accessibilityLabel` (e.g., "Scan barcode with camera") to icon-only `TouchableOpacity` elements, along with `accessibilityState` for dynamic states like disabled or checked.
+
+## 2024-06-15 - Auto-Mapping Form Accessibility Props
+**Learning:** In reusable form components (like Input), developers often pass visual `label` and `error` props but forget to explicitly pass their corresponding accessibility attributes, leading to unannounced fields or errors for screen reader users.
+**Action:** Automatically map internal visual states (like `label` and `error` text) to their corresponding native accessibility attributes (`accessibilityLabel`, `accessibilityInvalid`, `accessibilityErrorMessage`) within the wrapper component by default to ensure accessibility is guaranteed regardless of the developer's implementation.

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -127,6 +127,13 @@ export const Input = forwardRef<TextInput, InputProps>(
             editable={editable}
             placeholderTextColor={theme.colors.muted}
             {...textInputProps}
+            accessibilityLabel={textInputProps.accessibilityLabel || label}
+            accessibilityState={{
+              disabled: !editable,
+              ...(textInputProps.accessibilityState || {})
+            }}
+            aria-invalid={hasError}
+            aria-errormessage={error}
           />
           {rightIcon}
         </View>


### PR DESCRIPTION
## **User description**
💡 **What:** Automatically maps standard visual component props (`label`, `error`, `editable`) to their corresponding native accessibility attributes (`accessibilityLabel`, `aria-invalid`, `aria-errormessage`, and `accessibilityState.disabled`) in the reusable `Input` component.

🎯 **Why:** Developers frequently pass visual labels and error messages to input components but forget to explicitly attach them to the native component's accessibility layer. By automatically mapping these at the wrapper component level, we guarantee that all usages of the `Input` component across the application will be correctly announced by screen readers without developers having to remember to do it manually every time.

♿ **Accessibility:**
- Implicitly links visual labels to the input for screen reader contexts.
- Implicitly marks inputs with errors as invalid.
- Implicitly announces error text.
- Implicitly announces the disabled state.

---
*PR created automatically by Jules for task [13485718761336860746](https://jules.google.com/task/13485718761336860746) started by @mknoufi*


___

## **CodeAnt-AI Description**
**Input fields now announce their label, error, and disabled state to screen readers by default**

### What Changed
- Input fields now use the visible label as the spoken label unless a screen-reader label is already provided
- Inputs marked as read-only now announce that they are disabled
- Inputs with errors now announce that they are invalid and connect the error message for assistive technologies
- Existing accessibility settings still take priority when already set

### Impact
`✅ Clearer form labels for screen readers`
`✅ Fewer missed input errors`
`✅ Better disabled-state announcements`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
