### PR TITLE
🎨 Palette: Add accessibility props to RippleButton

### DIFF
--- a/frontend/src/components/ui/RippleButton.tsx
+++ b/frontend/src/components/ui/RippleButton.tsx
@@ -58,6 +58,8 @@ interface RippleButtonProps {
   style?: ViewStyle;
   textStyle?: TextStyle;
   hapticFeedback?: "light" | "medium" | "heavy" | "none";
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
 }
 
 const variantStyles = {
@@ -82,10 +84,7 @@ const variantStyles = {
     rippleColor: "rgba(255, 255, 255, 0.3)",
   },
   error: {
-    gradient: [
-      auroraTheme.colors.error[500],
-      auroraTheme.colors.error[700],
-    ] as const,
+    gradient: [auroraTheme.colors.error[500], auroraTheme.colors.error[700]] as const,
     textColor: auroraTheme.colors.text.primary,
     rippleColor: "rgba(255, 255, 255, 0.3)",
   },
@@ -146,6 +145,8 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
   style,
   textStyle,
   hapticFeedback = "medium",
+  accessibilityLabel,
+  accessibilityHint,
 }) => {
   const [buttonLayout, setButtonLayout] = useState({ width: 0, height: 0 });
   const rippleScale = useSharedValue(0);
@@ -169,7 +170,7 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
     // Calculate max ripple size
     const maxDistance = Math.sqrt(
       Math.pow(Math.max(locationX, buttonLayout.width - locationX), 2) +
-      Math.pow(Math.max(locationY, buttonLayout.height - locationY), 2),
+        Math.pow(Math.max(locationY, buttonLayout.height - locationY), 2)
     );
     const maxScale = (maxDistance * 2) / 10; // 10 is base ripple size
 
@@ -255,11 +256,7 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
 
       {/* Ripple effect */}
       <Animated.View
-        style={[
-          styles.ripple,
-          { backgroundColor: variantStyle.rippleColor },
-          rippleStyle,
-        ]}
+        style={[styles.ripple, { backgroundColor: variantStyle.rippleColor }, rippleStyle]}
         pointerEvents="none"
       />
     </>
@@ -276,12 +273,20 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
     fullWidth ? styles.fullWidth : {},
     variant === "outline"
       ? {
-        borderWidth: 2,
-        borderColor: auroraTheme.colors.primary[400],
-      }
+          borderWidth: 2,
+          borderColor: auroraTheme.colors.primary[400],
+        }
       : {},
     style ?? {},
   ];
+
+  const accessibilityProps = {
+    accessibilityRole: "button" as const,
+    accessibilityLabel:
+      accessibilityLabel || label || (typeof children === "string" ? children : undefined),
+    accessibilityHint: accessibilityHint,
+    accessibilityState: { disabled: disabled || loading, busy: loading },
+  };
 
   if (variant === "ghost" || variant === "outline") {
     return (
@@ -291,6 +296,7 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
         onLayout={handleLayout}
         disabled={disabled || loading}
         activeOpacity={0.8}
+        {...accessibilityProps}
       >
         {content}
       </TouchableOpacity>
@@ -304,6 +310,7 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
       disabled={disabled || loading}
       activeOpacity={0.9}
       style={[fullWidth && styles.fullWidth]}
+      {...accessibilityProps}
     >
       <LinearGradient
         colors={variantStyle.gradient as readonly [string, string, ...string[]]}


### PR DESCRIPTION
## **User description**
💡 **What**: Added `accessibilityRole`, `accessibilityLabel`, `accessibilityHint`, and `accessibilityState` props to the `RippleButton` component.

🎯 **Why**: Because the `RippleButton` is built using a raw `TouchableOpacity` wrapper, screen readers would not announce it as a button, nor announce its active text or disabled/loading state properly. Providing these standard properties ensures our screen reader users have proper context about their function.

♿ **Accessibility**: Enhanced interactive support and dynamic state bindings for disabled and busy properties. Added proper default fallbacks for `accessibilityLabel` based on props, `label`, or `children`.

---
*PR created automatically by Jules for task [7577447247671525690](https://jules.google.com/task/7577447247671525690) started by @mknoufi*


___

## **CodeAnt-AI Description**
**Make RippleButton announce itself and its state to screen readers**

### What Changed
- RippleButton now identifies as a button for assistive technology and can expose a custom label and hint
- If no label is provided, it falls back to the button text so screen readers still announce a useful name
- Disabled and loading states are now announced so users can tell when the button cannot be used or is busy

### Impact
`✅ Clearer screen reader button labels`
`✅ Fewer inaccessible disabled or loading controls`
`✅ Better app navigation for assistive technology users`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
