### PR TITLE
🎨 Palette: Fix RippleButton loading layout shift & add accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-28 - Icon-Only Button Accessibility in Search
 **Learning:** Icon-only action buttons (like scan barcode, voice search, and submit inputs) are completely inaccessible to screen reader users if missing proper accessibility props, as they provide no context about their function.
 **Action:** Always add `accessibilityRole="button"` and an explicit `accessibilityLabel` (e.g., "Scan barcode with camera") to icon-only `TouchableOpacity` elements, along with `accessibilityState` for dynamic states like disabled or checked.
+
+## 2024-06-25 - Custom Button Layout Shifts & Accessibility
+**Learning:** Replacing button text with an `ActivityIndicator` during a loading state causes the button to collapse its width if not explicitly set. Additionally, custom `TouchableOpacity` buttons like `RippleButton` lose native accessibility features.
+**Action:** Always maintain the text element with `opacity: 0` and absolutely position the loading indicator to reserve layout space. Ensure custom buttons expose and dynamically pass down `accessibilityRole`, `accessibilityLabel`, and `accessibilityState` (including `busy: loading`).

--- a/frontend/src/components/ui/RippleButton.tsx
+++ b/frontend/src/components/ui/RippleButton.tsx
@@ -58,6 +58,8 @@ interface RippleButtonProps {
   style?: ViewStyle;
   textStyle?: TextStyle;
   hapticFeedback?: "light" | "medium" | "heavy" | "none";
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
 }
 
 const variantStyles = {
@@ -82,10 +84,7 @@ const variantStyles = {
     rippleColor: "rgba(255, 255, 255, 0.3)",
   },
   error: {
-    gradient: [
-      auroraTheme.colors.error[500],
-      auroraTheme.colors.error[700],
-    ] as const,
+    gradient: [auroraTheme.colors.error[500], auroraTheme.colors.error[700]] as const,
     textColor: auroraTheme.colors.text.primary,
     rippleColor: "rgba(255, 255, 255, 0.3)",
   },
@@ -146,6 +145,8 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
   style,
   textStyle,
   hapticFeedback = "medium",
+  accessibilityLabel,
+  accessibilityHint,
 }) => {
   const [buttonLayout, setButtonLayout] = useState({ width: 0, height: 0 });
   const rippleScale = useSharedValue(0);
@@ -169,7 +170,7 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
     // Calculate max ripple size
     const maxDistance = Math.sqrt(
       Math.pow(Math.max(locationX, buttonLayout.width - locationX), 2) +
-      Math.pow(Math.max(locationY, buttonLayout.height - locationY), 2),
+        Math.pow(Math.max(locationY, buttonLayout.height - locationY), 2)
     );
     const maxScale = (maxDistance * 2) / 10; // 10 is base ripple size
 
@@ -215,51 +216,49 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
 
   const content = (
     <>
-      {loading ? (
-        <ActivityIndicator size="small" color={variantStyle.textColor} />
-      ) : (
-        <View style={styles.contentContainer}>
-          {icon && iconPosition === "left" && (
-            <Ionicons
-              name={icon}
-              size={sizeStyle.iconSize}
-              color={variantStyle.textColor}
-              style={styles.iconLeft}
-            />
-          )}
-          {(label || children) && (
-            <Text
-              style={[
-                styles.label,
-                {
-                  fontSize: sizeStyle.fontSize,
-                  color: variantStyle.textColor,
-                  fontFamily: auroraTheme.typography.fontFamily.label,
-                },
-                textStyle,
-              ]}
-            >
-              {label || children}
-            </Text>
-          )}
-          {icon && iconPosition === "right" && (
-            <Ionicons
-              name={icon}
-              size={sizeStyle.iconSize}
-              color={variantStyle.textColor}
-              style={styles.iconRight}
-            />
-          )}
+      <View style={[styles.contentContainer, loading && { opacity: 0 }]}>
+        {icon && iconPosition === "left" && (
+          <Ionicons
+            name={icon}
+            size={sizeStyle.iconSize}
+            color={variantStyle.textColor}
+            style={styles.iconLeft}
+          />
+        )}
+        {(label || children) && (
+          <Text
+            style={[
+              styles.label,
+              {
+                fontSize: sizeStyle.fontSize,
+                color: variantStyle.textColor,
+                fontFamily: auroraTheme.typography.fontFamily.label,
+              },
+              textStyle,
+            ]}
+          >
+            {label || children}
+          </Text>
+        )}
+        {icon && iconPosition === "right" && (
+          <Ionicons
+            name={icon}
+            size={sizeStyle.iconSize}
+            color={variantStyle.textColor}
+            style={styles.iconRight}
+          />
+        )}
+      </View>
+
+      {loading && (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="small" color={variantStyle.textColor} />
         </View>
       )}
 
       {/* Ripple effect */}
       <Animated.View
-        style={[
-          styles.ripple,
-          { backgroundColor: variantStyle.rippleColor },
-          rippleStyle,
-        ]}
+        style={[styles.ripple, { backgroundColor: variantStyle.rippleColor }, rippleStyle]}
         pointerEvents="none"
       />
     </>
@@ -276,9 +275,9 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
     fullWidth ? styles.fullWidth : {},
     variant === "outline"
       ? {
-        borderWidth: 2,
-        borderColor: auroraTheme.colors.primary[400],
-      }
+          borderWidth: 2,
+          borderColor: auroraTheme.colors.primary[400],
+        }
       : {},
     style ?? {},
   ];
@@ -291,6 +290,10 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
         onLayout={handleLayout}
         disabled={disabled || loading}
         activeOpacity={0.8}
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel || label}
+        accessibilityHint={accessibilityHint}
+        accessibilityState={{ disabled: disabled || loading, busy: loading }}
       >
         {content}
       </TouchableOpacity>
@@ -304,6 +307,10 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
       disabled={disabled || loading}
       activeOpacity={0.9}
       style={[fullWidth && styles.fullWidth]}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel || label}
+      accessibilityHint={accessibilityHint}
+      accessibilityState={{ disabled: disabled || loading, busy: loading }}
     >
       <LinearGradient
         colors={variantStyle.gradient as readonly [string, string, ...string[]]}
@@ -343,6 +350,11 @@ const styles = StyleSheet.create({
   },
   iconRight: {
     marginLeft: auroraTheme.spacing.sm,
+  },
+  loadingContainer: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: "center",
+    alignItems: "center",
   },
   ripple: {
     position: "absolute",


### PR DESCRIPTION
## **User description**
💡 **What:** 
- Updated `RippleButton` to position the `ActivityIndicator` absolutely over visually hidden content (`opacity: 0`).
- Added missing explicit accessibility props (`accessibilityRole`, `accessibilityLabel`, `accessibilityHint`, `accessibilityState`).

🎯 **Why:** 
- Custom buttons using `ActivityIndicator` often suffer layout shifts if width shrinks during loading. Keeping text loaded but hidden fixes this dimension shift.
- Custom `TouchableOpacity` components require explicitly passing a role and screen-reader specific values to function robustly.

♿ **Accessibility:** 
- Exposes proper properties to be announced smoothly by screen readers (esp. dynamic states like `disabled` and `busy`).

---
*PR created automatically by Jules for task [11897997591426861500](https://jules.google.com/task/11897997591426861500) started by @mknoufi*


___

## **CodeAnt-AI Description**
**Keep RippleButton size stable while loading and expose clearer accessibility info**

### What Changed
- The button now keeps its text and icon space reserved when loading, so it no longer shrinks or shifts layout while the spinner is shown.
- The loading spinner is shown on top of the existing button content instead of replacing it.
- RippleButton now announces itself as a button and can expose a custom label and hint for screen readers.
- Screen readers now get the correct disabled and busy state when the button is loading or unavailable.

### Impact
`✅ No button layout shift during loading`
`✅ Clearer screen reader labels for custom buttons`
`✅ More accurate loading and disabled announcements`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
