### PR TITLE
🎨 Palette: RippleButton UX stability & accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-28 - Icon-Only Button Accessibility in Search
 **Learning:** Icon-only action buttons (like scan barcode, voice search, and submit inputs) are completely inaccessible to screen reader users if missing proper accessibility props, as they provide no context about their function.
 **Action:** Always add `accessibilityRole="button"` and an explicit `accessibilityLabel` (e.g., "Scan barcode with camera") to icon-only `TouchableOpacity` elements, along with `accessibilityState` for dynamic states like disabled or checked.
+
+## 2026-02-28 - Dynamic Button Layout Shifts during Async Tasks
+**Learning:** Conditionally rendering a spinner instead of button content during loading states causes the button to collapse or shift in width, which creates an unpleasant UI jank for the user and makes the interface feel unstable.
+**Action:** When a dynamic button enters a loading state, instead of removing its text/icon content, maintain it in the DOM with `opacity: 0` to reserve its layout space, and overlay the loading spinner using `position: 'absolute'`. This ensures a seamless, jank-free transition.

--- a/frontend/src/components/ui/RippleButton.tsx
+++ b/frontend/src/components/ui/RippleButton.tsx
@@ -58,6 +58,8 @@ interface RippleButtonProps {
   style?: ViewStyle;
   textStyle?: TextStyle;
   hapticFeedback?: "light" | "medium" | "heavy" | "none";
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
 }
 
 const variantStyles = {
@@ -82,10 +84,7 @@ const variantStyles = {
     rippleColor: "rgba(255, 255, 255, 0.3)",
   },
   error: {
-    gradient: [
-      auroraTheme.colors.error[500],
-      auroraTheme.colors.error[700],
-    ] as const,
+    gradient: [auroraTheme.colors.error[500], auroraTheme.colors.error[700]] as const,
     textColor: auroraTheme.colors.text.primary,
     rippleColor: "rgba(255, 255, 255, 0.3)",
   },
@@ -146,6 +145,8 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
   style,
   textStyle,
   hapticFeedback = "medium",
+  accessibilityLabel,
+  accessibilityHint,
 }) => {
   const [buttonLayout, setButtonLayout] = useState({ width: 0, height: 0 });
   const rippleScale = useSharedValue(0);
@@ -169,7 +170,7 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
     // Calculate max ripple size
     const maxDistance = Math.sqrt(
       Math.pow(Math.max(locationX, buttonLayout.width - locationX), 2) +
-      Math.pow(Math.max(locationY, buttonLayout.height - locationY), 2),
+        Math.pow(Math.max(locationY, buttonLayout.height - locationY), 2)
     );
     const maxScale = (maxDistance * 2) / 10; // 10 is base ripple size
 
@@ -215,51 +216,48 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
 
   const content = (
     <>
-      {loading ? (
-        <ActivityIndicator size="small" color={variantStyle.textColor} />
-      ) : (
-        <View style={styles.contentContainer}>
-          {icon && iconPosition === "left" && (
-            <Ionicons
-              name={icon}
-              size={sizeStyle.iconSize}
-              color={variantStyle.textColor}
-              style={styles.iconLeft}
-            />
-          )}
-          {(label || children) && (
-            <Text
-              style={[
-                styles.label,
-                {
-                  fontSize: sizeStyle.fontSize,
-                  color: variantStyle.textColor,
-                  fontFamily: auroraTheme.typography.fontFamily.label,
-                },
-                textStyle,
-              ]}
-            >
-              {label || children}
-            </Text>
-          )}
-          {icon && iconPosition === "right" && (
-            <Ionicons
-              name={icon}
-              size={sizeStyle.iconSize}
-              color={variantStyle.textColor}
-              style={styles.iconRight}
-            />
-          )}
+      {loading && (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="small" color={variantStyle.textColor} />
         </View>
       )}
+      <View style={[styles.contentContainer, loading && { opacity: 0 }]}>
+        {icon && iconPosition === "left" && (
+          <Ionicons
+            name={icon}
+            size={sizeStyle.iconSize}
+            color={variantStyle.textColor}
+            style={styles.iconLeft}
+          />
+        )}
+        {(label || children) && (
+          <Text
+            style={[
+              styles.label,
+              {
+                fontSize: sizeStyle.fontSize,
+                color: variantStyle.textColor,
+                fontFamily: auroraTheme.typography.fontFamily.label,
+              },
+              textStyle,
+            ]}
+          >
+            {label || children}
+          </Text>
+        )}
+        {icon && iconPosition === "right" && (
+          <Ionicons
+            name={icon}
+            size={sizeStyle.iconSize}
+            color={variantStyle.textColor}
+            style={styles.iconRight}
+          />
+        )}
+      </View>
 
       {/* Ripple effect */}
       <Animated.View
-        style={[
-          styles.ripple,
-          { backgroundColor: variantStyle.rippleColor },
-          rippleStyle,
-        ]}
+        style={[styles.ripple, { backgroundColor: variantStyle.rippleColor }, rippleStyle]}
         pointerEvents="none"
       />
     </>
@@ -276,12 +274,20 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
     fullWidth ? styles.fullWidth : {},
     variant === "outline"
       ? {
-        borderWidth: 2,
-        borderColor: auroraTheme.colors.primary[400],
-      }
+          borderWidth: 2,
+          borderColor: auroraTheme.colors.primary[400],
+        }
       : {},
     style ?? {},
   ];
+
+  const accessibilityProps = {
+    accessibilityRole: "button" as const,
+    accessibilityLabel:
+      accessibilityLabel || label || (typeof children === "string" ? children : undefined),
+    accessibilityHint,
+    accessibilityState: { disabled: !!disabled, busy: !!loading },
+  };
 
   if (variant === "ghost" || variant === "outline") {
     return (
@@ -291,6 +297,7 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
         onLayout={handleLayout}
         disabled={disabled || loading}
         activeOpacity={0.8}
+        {...accessibilityProps}
       >
         {content}
       </TouchableOpacity>
@@ -304,6 +311,7 @@ export const RippleButton: React.FC<RippleButtonProps> = ({
       disabled={disabled || loading}
       activeOpacity={0.9}
       style={[fullWidth && styles.fullWidth]}
+      {...accessibilityProps}
     >
       <LinearGradient
         colors={variantStyle.gradient as readonly [string, string, ...string[]]}
@@ -333,6 +341,12 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
+  },
+  loadingContainer: {
+    position: "absolute",
+    justifyContent: "center",
+    alignItems: "center",
+    zIndex: 1,
   },
   label: {
     fontWeight: "600",


### PR DESCRIPTION
## **User description**
Mapped accessibility props in RippleButton to improve screen reader context, and improved dynamic loading stability by keeping the button text rendered with `opacity: 0` to reserve layout width, preventing UI jitter.

---
*PR created automatically by Jules for task [5741872888026718421](https://jules.google.com/task/5741872888026718421) started by @mknoufi*


___

## **CodeAnt-AI Description**
**Make loading RippleButtons stay stable and announce their state clearly**

### What Changed
- Ripple buttons now keep their text and icon space while loading, so the button does not shrink or jump when the spinner appears
- The loading spinner is shown on top of the existing content instead of replacing it
- Ripple buttons now expose a clearer label, hint, and button state for screen readers, including disabled and busy states

### Impact
`✅ Fewer button layout shifts during loading`
`✅ Clearer screen reader feedback for buttons`
`✅ Smoother async button interactions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
