### PR TITLE
🎨 Palette: Prevent Button layout shift on loading and enhance accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-28 - Icon-Only Button Accessibility in Search
 **Learning:** Icon-only action buttons (like scan barcode, voice search, and submit inputs) are completely inaccessible to screen reader users if missing proper accessibility props, as they provide no context about their function.
 **Action:** Always add `accessibilityRole="button"` and an explicit `accessibilityLabel` (e.g., "Scan barcode with camera") to icon-only `TouchableOpacity` elements, along with `accessibilityState` for dynamic states like disabled or checked.
+
+## 2026-06-25 - Prevent Button Layout Jumps during Loading
+**Learning:** Swapping button text for an ActivityIndicator can cause layout jumping because the ActivityIndicator dimensions differ from the text. This is jarring and can lead to accidental misclicks in adjacent elements.
+**Action:** Instead of swapping elements, keep the text mounted but set `opacity: loading ? 0 : 1` to reserve its space, and absolutely position the `ActivityIndicator` over it. This guarantees the button layout remains static during the loading state.

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode } from "react";
 import {
   TouchableOpacity,
   Text,
@@ -7,21 +7,24 @@ import {
   TextStyle,
   GestureResponderEvent,
   ActivityIndicator,
-} from 'react-native';
+  View,
+} from "react-native";
 
 interface ButtonProps {
   title: string;
   onPress: (event: GestureResponderEvent) => void;
-  variant?: 'primary' | 'secondary' | 'danger' | 'ghost';
-  size?: 'small' | 'medium' | 'large';
+  variant?: "primary" | "secondary" | "danger" | "ghost";
+  size?: "small" | "medium" | "large";
   disabled?: boolean;
   loading?: boolean;
   icon?: ReactNode;
-  iconPosition?: 'left' | 'right';
+  iconPosition?: "left" | "right";
   fullWidth?: boolean;
   style?: StyleProp<ViewStyle>;
   textStyle?: StyleProp<TextStyle>;
   testID?: string;
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
 }
 
 const sizeMap = {
@@ -31,47 +34,49 @@ const sizeMap = {
 } as const;
 
 const variantColors = {
-  primary: { bg: '#007AFF', text: '#FFFFFF' },
-  secondary: { bg: '#E5E5E5', text: '#000000' },
-  danger: { bg: '#FF3B30', text: '#FFFFFF' },
-  ghost: { bg: 'transparent', text: '#007AFF' },
+  primary: { bg: "#007AFF", text: "#FFFFFF" },
+  secondary: { bg: "#E5E5E5", text: "#000000" },
+  danger: { bg: "#FF3B30", text: "#FFFFFF" },
+  ghost: { bg: "transparent", text: "#007AFF" },
 } as const;
 
 export const Button: React.FC<ButtonProps> = ({
   title,
   onPress,
-  variant = 'primary',
-  size = 'medium',
+  variant = "primary",
+  size = "medium",
   disabled = false,
   loading = false,
   icon,
-  iconPosition = 'left',
+  iconPosition = "left",
   fullWidth = false,
   style,
   textStyle,
   testID,
+  accessibilityLabel,
+  accessibilityHint,
 }) => {
   const isDisabled = disabled || loading;
   const sizeStyles = sizeMap[size];
   const colors = variantColors[variant];
 
   const buttonStyles: ViewStyle = {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
     backgroundColor: colors.bg,
     paddingVertical: sizeStyles.paddingVertical,
     paddingHorizontal: sizeStyles.paddingHorizontal,
     borderRadius: 8,
     opacity: isDisabled ? 0.5 : 1,
-    ...(fullWidth && { width: '100%' }),
-    ...(variant === 'ghost' && { borderWidth: 1, borderColor: colors.text }),
+    ...(fullWidth && { width: "100%" }),
+    ...(variant === "ghost" && { borderWidth: 1, borderColor: colors.text }),
   };
 
   const textStyles: TextStyle = {
     color: colors.text,
     fontSize: sizeStyles.fontSize,
-    fontWeight: '600',
+    fontWeight: "600",
     marginHorizontal: icon ? 4 : 0,
   };
 
@@ -82,15 +87,25 @@ export const Button: React.FC<ButtonProps> = ({
       disabled={isDisabled}
       testID={testID}
       activeOpacity={0.7}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel || title}
+      accessibilityHint={accessibilityHint}
+      accessibilityState={{ disabled: isDisabled, busy: loading }}
     >
-      {loading ? (
-        <ActivityIndicator color={colors.text} size="small" />
-      ) : (
-        <>
-          {icon && iconPosition === 'left' && icon}
-          <Text style={[textStyles, textStyle]}>{title}</Text>
-          {icon && iconPosition === 'right' && icon}
-        </>
+      <View
+        style={{
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "center",
+          opacity: loading ? 0 : 1,
+        }}
+      >
+        {icon && iconPosition === "left" && icon}
+        <Text style={[textStyles, textStyle]}>{title}</Text>
+        {icon && iconPosition === "right" && icon}
+      </View>
+      {loading && (
+        <ActivityIndicator style={{ position: "absolute" }} color={colors.text} size="small" />
       )}
     </TouchableOpacity>
   );


### PR DESCRIPTION
## **User description**
💡 What: Prevented `Button` layout shift during its loading state by preserving the text with `opacity: 0` instead of unmounting it. Additionally, exposed `accessibilityLabel` and `accessibilityHint` while enforcing `accessibilityRole="button"` and `accessibilityState`.
🎯 Why: Layout shifts during loading cause jarring experiences and accidental misclicks. Icon-only buttons or those with custom labels were previously inaccessible to screen readers because `TouchableOpacity` was missing explicit roles and states.
♿ Accessibility:
- Added explicit `accessibilityRole="button"`.
- Wired `accessibilityLabel` with a fallback to `title`.
- Mapped `accessibilityState={{ disabled: isDisabled, busy: loading }}` to correctly announce the button's loading and disabled statuses.

---
*PR created automatically by Jules for task [13010360547956550027](https://jules.google.com/task/13010360547956550027) started by @mknoufi*


___

## **CodeAnt-AI Description**
**Keep button size stable while it is loading and improve screen reader support**

### What Changed
- Button text now stays in place during loading, so the button keeps the same size instead of jumping when the spinner appears
- The loading spinner is shown on top of the text without changing the button layout
- Button screen reader support now includes a clear button role, optional custom label and hint, and accurate disabled/loading status

### Impact
`✅ Fewer button layout jumps`
`✅ Reduced accidental misclicks during loading`
`✅ Clearer screen reader feedback for buttons`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
