### PR TITLE
🎨 Palette: Add accessibility props to SpeedDialMenu components

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-28 - Icon-Only Button Accessibility in Search
 **Learning:** Icon-only action buttons (like scan barcode, voice search, and submit inputs) are completely inaccessible to screen reader users if missing proper accessibility props, as they provide no context about their function.
 **Action:** Always add `accessibilityRole="button"` and an explicit `accessibilityLabel` (e.g., "Scan barcode with camera") to icon-only `TouchableOpacity` elements, along with `accessibilityState` for dynamic states like disabled or checked.
+
+## 2024-07-02 - Floating Action Menu Accessibility
+**Learning:** Floating action menus and speed dial components are complex for screen reader users if not properly labelled, as they involve a main trigger that toggles visibility of sub-actions and a backdrop overlay.
+**Action:** Always add `accessibilityRole="button"`, `accessibilityLabel`, and `accessibilityState={{ expanded: boolean }}` to the main trigger. Sub-actions must also be explicitly labeled as buttons. The backdrop overlay requires `accessible={true}`, `accessibilityRole="button"`, and an `accessibilityLabel` (e.g., "Close speed dial menu") to allow screen reader users to dismiss the menu.

--- a/frontend/src/components/ui/SpeedDialMenu.tsx
+++ b/frontend/src/components/ui/SpeedDialMenu.tsx
@@ -10,13 +10,7 @@
  */
 
 import React, { useState, useEffect } from "react";
-import {
-  View,
-  Text,
-  StyleSheet,
-  TouchableOpacity,
-  Platform,
-} from "react-native";
+import { View, Text, StyleSheet, TouchableOpacity, Platform } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { LinearGradient } from "expo-linear-gradient";
 import { BlurView } from "expo-blur";
@@ -67,13 +61,9 @@ const SpeedDialActionItem: React.FC<SpeedDialActionItemProps> = ({
     const translateY = interpolate(
       animationProgress.value,
       [0, 1],
-      [0, -(72 + auroraTheme.spacing.md) * (index + 1)],
+      [0, -(72 + auroraTheme.spacing.md) * (index + 1)]
     );
-    const opacity = interpolate(
-      animationProgress.value,
-      [0, 0.5, 1],
-      [0, 0.5, 1],
-    );
+    const opacity = interpolate(animationProgress.value, [0, 0.5, 1], [0, 0.5, 1]);
     const scale = interpolate(animationProgress.value, [0, 1], [0.3, 1]);
 
     return {
@@ -87,6 +77,8 @@ const SpeedDialActionItem: React.FC<SpeedDialActionItemProps> = ({
       style={[styles.actionButton, actionStyle]}
       onPress={() => onPress(action)}
       activeOpacity={0.9}
+      accessibilityRole="button"
+      accessibilityLabel={action.label}
     >
       <View style={styles.actionContent}>
         {/* Label */}
@@ -110,20 +102,13 @@ const SpeedDialActionItem: React.FC<SpeedDialActionItemProps> = ({
             colors={
               action.color
                 ? [action.color, action.color]
-                : [
-                  auroraTheme.colors.aurora.secondary[0],
-                  auroraTheme.colors.aurora.secondary[1],
-                ]
+                : [auroraTheme.colors.aurora.secondary[0], auroraTheme.colors.aurora.secondary[1]]
             }
             start={{ x: 0, y: 0 }}
             end={{ x: 1, y: 1 }}
             style={styles.iconGradient}
           >
-            <Ionicons
-              name={action.icon}
-              size={24}
-              color={auroraTheme.colors.text.primary}
-            />
+            <Ionicons name={action.icon} size={24} color={auroraTheme.colors.text.primary} />
             {action.badge !== undefined && action.badge > 0 && (
               <View style={styles.badge}>
                 <Text style={styles.badgeText}>{action.badge}</Text>
@@ -213,15 +198,14 @@ export const SpeedDialMenu: React.FC<SpeedDialMenuProps> = ({
   return (
     <>
       {/* Backdrop */}
-      <AnimatedBlurView
-        intensity={20}
-        tint="dark"
-        style={[StyleSheet.absoluteFill, backdropStyle]}
-      >
+      <AnimatedBlurView intensity={20} tint="dark" style={[StyleSheet.absoluteFill, backdropStyle]}>
         <TouchableOpacity
           style={StyleSheet.absoluteFill}
           onPress={toggleMenu}
           activeOpacity={1}
+          accessible={true}
+          accessibilityRole="button"
+          accessibilityLabel="Close speed dial menu"
         />
       </AnimatedBlurView>
 
@@ -243,6 +227,9 @@ export const SpeedDialMenu: React.FC<SpeedDialMenuProps> = ({
           style={styles.mainButton}
           onPress={toggleMenu}
           activeOpacity={0.9}
+          accessibilityRole="button"
+          accessibilityLabel={isOpen ? "Close speed dial menu" : "Open speed dial menu"}
+          accessibilityState={{ expanded: isOpen }}
         >
           <LinearGradient
             colors={mainColor}
@@ -251,11 +238,7 @@ export const SpeedDialMenu: React.FC<SpeedDialMenuProps> = ({
             style={styles.mainGradient}
           >
             <Animated.View style={mainButtonStyle}>
-              <Ionicons
-                name={mainIcon}
-                size={32}
-                color={auroraTheme.colors.text.primary}
-              />
+              <Ionicons name={mainIcon} size={32} color={auroraTheme.colors.text.primary} />
             </Animated.View>
           </LinearGradient>
         </TouchableOpacity>


### PR DESCRIPTION
## **User description**
💡 **What:** Added dynamic accessibility roles and labels to the main trigger button, sub-action buttons, and the backdrop overlay in the `SpeedDialMenu` component.
🎯 **Why:** To ensure that screen reader users can fully comprehend, toggle, navigate through the menu choices, and safely dismiss the floating speed dial menu.
♿ **Accessibility:**
  - Added `accessibilityRole="button"`, `accessibilityLabel`, and `accessibilityState={{ expanded }}` to the main trigger.
  - Added `accessibilityRole="button"` and dynamic `accessibilityLabel` to sub-actions.
  - Added `accessible={true}`, `accessibilityRole="button"`, and `accessibilityLabel="Close speed dial menu"` to the backdrop overlay to make it identifiable as an escape mechanism.

---
*PR created automatically by Jules for task [5728860706322915924](https://jules.google.com/task/5728860706322915924) started by @mknoufi*


___

## **CodeAnt-AI Description**
**Add screen reader labels and states to the speed dial menu**

### What Changed
- The main speed dial button now announces whether the menu is open or closed and exposes its expanded state to assistive technologies
- Each menu action now has a clear spoken label so screen reader users can identify and activate it
- The backdrop can now be used as a labeled close target, making it easier to dismiss the menu without guessing

### Impact
`✅ Easier speed dial navigation with screen readers`
`✅ Clearer open/close feedback for floating menus`
`✅ Safer menu dismissal for accessibility users`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
