### PR TITLE
🎨 Palette: Map accessibility props for Input component

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-28 - Icon-Only Button Accessibility in Search
 **Learning:** Icon-only action buttons (like scan barcode, voice search, and submit inputs) are completely inaccessible to screen reader users if missing proper accessibility props, as they provide no context about their function.
 **Action:** Always add `accessibilityRole="button"` and an explicit `accessibilityLabel` (e.g., "Scan barcode with camera") to icon-only `TouchableOpacity` elements, along with `accessibilityState` for dynamic states like disabled or checked.
+
+## 2024-03-05 - Reusable Input Component Accessibility
+**Learning:** Reusable form input components that accept `label` and `error` props often visually display these states but fail to programmatically associate them with the underlying native `TextInput`.
+**Action:** When building custom input components, ensure custom props like `label` and `error` are mapped to their corresponding accessibility properties (`accessibilityLabel`, `aria-invalid`, `accessibilityErrorMessage`) on the underlying native element.

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, forwardRef } from 'react';
+import React, { ReactNode, forwardRef } from "react";
 import {
   TextInput,
   TextInputProps,
@@ -7,10 +7,10 @@ import {
   StyleProp,
   ViewStyle,
   TextStyle,
-} from 'react-native';
-import { useThemeContext } from '../../theme/ThemeContext';
+} from "react-native";
+import { useThemeContext } from "../../theme/ThemeContext";
 
-interface InputProps extends Omit<TextInputProps, 'style'> {
+interface InputProps extends Omit<TextInputProps, "style"> {
   label?: string;
   error?: string;
   helperText?: string;
@@ -21,8 +21,8 @@ interface InputProps extends Omit<TextInputProps, 'style'> {
   labelStyle?: StyleProp<TextStyle>;
   errorStyle?: StyleProp<TextStyle>;
   helperTextStyle?: StyleProp<TextStyle>;
-  variant?: 'outlined' | 'filled' | 'underlined';
-  size?: 'small' | 'medium' | 'large';
+  variant?: "outlined" | "filled" | "underlined";
+  size?: "small" | "medium" | "large";
   required?: boolean;
 }
 
@@ -45,8 +45,8 @@ export const Input = forwardRef<TextInput, InputProps>(
       labelStyle,
       errorStyle,
       helperTextStyle,
-      variant = 'outlined',
-      size = 'medium',
+      variant = "outlined",
+      size = "medium",
       required = false,
       editable = true,
       ...textInputProps
@@ -59,13 +59,13 @@ export const Input = forwardRef<TextInput, InputProps>(
 
     const getInputContainerStyles = (): ViewStyle => {
       const baseStyles: ViewStyle = {
-        flexDirection: 'row',
-        alignItems: 'center',
+        flexDirection: "row",
+        alignItems: "center",
         ...sizeStyles,
       };
 
       switch (variant) {
-        case 'outlined':
+        case "outlined":
           return {
             ...baseStyles,
             borderWidth: 1,
@@ -77,7 +77,7 @@ export const Input = forwardRef<TextInput, InputProps>(
             borderRadius: 8,
             backgroundColor: editable ? theme.colors.surface : theme.colors.surfaceElevated,
           };
-        case 'filled':
+        case "filled":
           return {
             ...baseStyles,
             backgroundColor: editable ? theme.colors.surfaceElevated : theme.colors.borderLight,
@@ -85,7 +85,7 @@ export const Input = forwardRef<TextInput, InputProps>(
             borderBottomWidth: 2,
             borderBottomColor: hasError ? theme.colors.danger : theme.colors.accent,
           };
-        case 'underlined':
+        case "underlined":
           return {
             ...baseStyles,
             borderBottomWidth: 1,
@@ -115,6 +115,9 @@ export const Input = forwardRef<TextInput, InputProps>(
           {leftIcon}
           <TextInput
             ref={ref}
+            accessibilityLabel={label}
+            aria-invalid={hasError}
+            aria-errormessage={error}
             style={[
               {
                 flex: 1,
@@ -132,12 +135,7 @@ export const Input = forwardRef<TextInput, InputProps>(
         </View>
 
         {error && (
-          <Text
-            style={[
-              { fontSize: 12, color: theme.colors.danger, marginTop: 4 },
-              errorStyle,
-            ]}
-          >
+          <Text style={[{ fontSize: 12, color: theme.colors.danger, marginTop: 4 }, errorStyle]}>
             {error}
           </Text>
         )}
@@ -157,4 +155,4 @@ export const Input = forwardRef<TextInput, InputProps>(
   }
 );
 
-Input.displayName = 'Input';
+Input.displayName = "Input";


### PR DESCRIPTION
## **User description**
💡 What: Added `accessibilityLabel`, `aria-invalid`, and `aria-errormessage` props to the native `TextInput` inside the reusable `Input` component.
🎯 Why: The component accepted `label` and `error` props but only rendered them visually. Screen reader users were unable to hear the input's context or its error state programmatically.
♿ Accessibility: Ensures full screen reader support for any form field using this reusable `Input` component.

---
*PR created automatically by Jules for task [6620535165197338498](https://jules.google.com/task/6620535165197338498) started by @mknoufi*


___

## **CodeAnt-AI Description**
**Make reusable input fields announce labels and errors to screen readers**

### What Changed
- Input fields now pass their label to assistive technology so screen reader users hear the field context
- Inputs with errors now expose an invalid state and connect the error message to the field
- Visual labels, required markers, and error text stay the same for sighted users

### Impact
`✅ Clearer form field announcements`
`✅ Fewer missed input errors`
`✅ Better screen reader form navigation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
